### PR TITLE
HT-1506: Configure relative url root

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
   - gem install bundler
 
 before_script:
+  - bundle exec rake keycard:migrate RAILS_ENV=test
   - bundle exec rails db:setup
 
 script:

--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,10 @@ gem 'sqlite3'
 group :development, :test do
   gem 'byebug'
   gem 'rubocop'
+  gem 'pry'
+  gem 'pry-byebug'
+  gem 'sqlite3'
+  gem 'faker'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -75,9 +75,8 @@ gem 'keycard'
 
 # Use MySQL as the database for Active Record
 gem 'mysql2'
-
 gem 'simple_form'
-gem 'sqlite3'
+gem 'dotenv-rails'
 
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -47,9 +47,6 @@ group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '< 3.2', '>= 3.0.5'
-  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
-  gem 'spring'
-  gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,7 @@ GEM
       xpath (~> 3.2)
     childprocess (1.0.1)
       rake (< 13.0)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -80,6 +81,8 @@ GEM
     ettin (1.3.0)
       deep_merge
     execjs (2.7.0)
+    faker (1.9.3)
+      i18n (>= 0.7)
     ffi (1.11.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -118,6 +121,12 @@ GEM
     parallel (1.17.0)
     parser (2.6.3.0)
       ast (~> 2.4.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-byebug (3.7.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
     public_suffix (3.1.1)
     puma (3.12.1)
     rack (2.0.7)
@@ -233,11 +242,14 @@ DEPENDENCIES
   capybara (>= 2.15, < 4.0)
   coffee-rails (~> 4.2)
   ettin
+  faker
   jbuilder (~> 2.5)
   jquery-rails
   keycard
   listen (>= 3.0.5, < 3.2)
   mysql2
+  pry
+  pry-byebug
   puma (~> 3.11)
   rails (~> 5.2.0)
   rails-controller-testing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,10 @@ GEM
     concurrent-ruby (1.1.5)
     crass (1.0.4)
     deep_merge (1.2.1)
+    dotenv (2.7.5)
+    dotenv-rails (2.7.5)
+      dotenv (= 2.7.5)
+      railties (>= 3.2, < 6.1)
     erubi (1.8.0)
     ettin (1.3.0)
       deep_merge
@@ -237,6 +241,7 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15, < 4.0)
   coffee-rails (~> 4.2)
+  dotenv-rails
   ettin
   faker
   jbuilder (~> 2.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,10 +197,6 @@ GEM
     simple_form (4.1.0)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
-    spring (2.1.0)
-    spring-watcher-listen (2.0.1)
-      listen (>= 2.7, < 4.0)
-      spring (>= 1.2, < 3.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -257,8 +253,6 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   selenium-webdriver
   simple_form
-  spring
-  spring-watcher-listen (~> 2.0.0)
   sqlite3
   turbolinks (~> 5)
   tzinfo-data

--- a/README.md
+++ b/README.md
@@ -11,19 +11,25 @@ $ bundle install
 
 ### 2. Database
 
-Use a local copy of the `ht_repository` database. Only the `ht_users` table
-is needed at the moment.
+Development mode uses sqlite3 with generated data. The keycard database also
+needs to be set up:
 
 ```
-$ ssh <some HathiTrust server>
-$ mysqldump -u <MySQL user> -p -h <MySQL host> ht_repository ht_users
+bundle exec rake keycard:migrate RAILS_ENV=development
+bundle exec rake keycard:migrate RAILS_ENV=test
+bundle exec rake db:setup
 ```
 
 ### 3. Testing
 
-We still need a CI setup, but for now we have Rails tests and RuboCop:
+```
+bundle exec rake test
+```
+
+### 4. Trying it out
 
 ```
-bin/rails test test/
-bundle exec rubocop
+bundle exec rails s
 ```
+
+Go to http://localhost:3000 and log in as `somebody@default.invalid`

--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -5,7 +5,7 @@ class SessionController < ApplicationController
 
   def new
     if login
-      redirect_back_or_to '/'
+      redirect_back_or_to root_path
     elsif Otis.config.allow_impersonation
       render 'shared/login_form'
     else
@@ -19,7 +19,7 @@ class SessionController < ApplicationController
     user = User.new(params[:username])
     if user
       auto_login(user)
-      redirect_back_or_to '/'
+      redirect_back_or_to root_path
     else
       render_forbidden
     end
@@ -27,13 +27,13 @@ class SessionController < ApplicationController
 
   def destroy
     logout
-    redirect_back_or_to '/'
+    redirect_back_or_to root_path
   end
 
   private
 
   def redirect_back_or_to(destination)
-    destination = session[:return_to] || destination || '/'
+    destination = session[:return_to] || destination || root_path
     session.delete(:return_to)
     redirect_to destination
   end

--- a/config.ru
+++ b/config.ru
@@ -4,4 +4,6 @@
 
 require_relative 'config/environment'
 
-run Rails.application
+map Otis.config.relative_url_root do
+  run Rails.application
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,6 +21,8 @@ module Otis
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 
+    config.relative_url_root = Otis.config.relative_url_root
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/database.yml
+++ b/config/database.yml
@@ -8,25 +8,20 @@
 # Use mysql2 as the database for Active Record
 #
 default: &default
-  adapter: mysql2
+  adapter: sqlite3
   encoding: utf8
   pool: 5
-  #timeout: 5000
-  username: root
-  #password:
-  #shost: localhost
-  #port: 3306
 
 development:
   <<: *default
-  database: ht_repository_development
+  database: db/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: ht_repository_test
+  database: db/test.sqlite3
 
 # Warning: Do not set username and password in the file!
 # Assign username and password to environment variables.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,3 +1,6 @@
 # Allow users to impersonate (login as) anyone -- useful for development
 allow_impersonation: false
 
+# By default don't allow any users to log in
+users: []
+

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,1 +1,2 @@
 allow_impersonation: true
+relative_url_root: ''

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,2 +1,10 @@
 allow_impersonation: true
-relative_url_root: ''
+relative_url_root: '/useradmin'
+
+keycard:
+  database:
+    adapter: sqlite
+    database: tmp/keycard_dev.sqlite3
+
+users:
+  - somebody@default.invalid

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -2,3 +2,11 @@ allow_impersonation: true
 
 users:
 - nobody@example.com
+
+# relative_url_root doesn't work for tests
+relative_url_root: '/'
+
+keycard:
+  database:
+    adapter: sqlite
+    database: tmp/keycard_test.sqlite3

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,23 +9,26 @@
 # you'll amass, the slower it'll run and the greater likelihood for issues).
 #
 # It's strongly recommended that you check this file into your version control system.
+#
+
+raise "Not for production use" if Rails.env.production?
 
 ActiveRecord::Schema.define(version: 0) do
-
-  create_table "ht_users", primary_key: "userid", id: :string, limit: 256, default: "", options: "ENGINE=MyISAM DEFAULT CHARSET=latin1", force: :cascade do |t|
-    t.string "displayname", limit: 128
-    t.string "email", limit: 128
-    t.string "activitycontact", limit: 128
-    t.string "approver", limit: 128
-    t.string "authorizer", limit: 128
-    t.string "usertype", limit: 32
-    t.string "role", limit: 32
-    t.string "access", limit: 32, default: "normal"
-    t.timestamp "expires", null: false, default: -> { 'CURRENT_TIMESTAMP' }
-    t.string "expire_type", limit: 32
-    t.string "iprestrict", limit: 1024
-    t.boolean "mfa"
-    t.string "identity_provider"
+  create_table :ht_users, id: false do |t|
+    t.string :userid, primary_key: true
+    t.string :displayname
+    t.string :email
+    t.string :activitycontact
+    t.string :approver
+    t.string :authorizer
+    t.string :usertype
+    t.string :role
+    t.string :access
+    t.timestamp :expires
+    t.string :expire_type
+    t.string :iprestrict
+    t.boolean :mfa
+    t.string :identity_provider
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,28 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+raise "Not for production use" if Rails.env.production?
+
+require 'faker'
+
+10.times do
+  u = HTUser.new(
+    userid: Faker::Internet.email,
+    displayname: Faker::Name.name,
+    email: Faker::Internet.email,
+    activitycontact: Faker::Internet.email,
+    approver: Faker::Internet.email,
+    authorizer: Faker::Internet.email,
+    usertype: ['staff','external','student'].sample,
+    role: ['corrections','cataloging','ssdproxy','crms','quality','staffdeveloper','staffsysadmin','replacement','ssd'].sample,
+    access: ['total','normal'].sample,
+    expires: Faker::Time.forward,
+    expire_type: ['expiresannually','expiresbiannually','expirescustom90','expirescustom60'].sample,
+    mfa: 0,
+    identity_provider: Faker::Internet.url
+  )
+  u.iprestrict = Faker::Internet.ip_v4_address
+  u.save
+
+end


### PR DESCRIPTION
This sets up relative url root handling that works in dev.

It does not work in test with a relative url root of anything other than '/' (among other things it complains there are no matching routes) for reasons I don't care to debug at the moment.

This also sets up default dev & test database config so that it can be used locally out of the box without requiring a mysql setup.