### PR TITLE
Build an actual object for the expiration_date

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,3 +35,6 @@ Style/ConditionalAssignment:
 
 Style/Documentation:
   Enabled: false
+
+Layout/AlignHash:
+  Enabled: false

--- a/app/models/expiration_date.rb
+++ b/app/models/expiration_date.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+class ExpirationDate
+  include Comparable
+
+  # What text describes the extension period?
+  # Build them up from a little helper class
+  class ExpiresTypeData
+    attr_reader :duration, :label
+
+    def initialize(label, duration)
+      @duration = duration
+      @label    = label
+    end
+
+    def to_s
+      @label
+    end
+  end
+
+  EXPIRES_TYPE = {
+    expiresannually:   ExpiresTypeData.new('1 year', 1.year).freeze,
+    expiresbiannually: ExpiresTypeData.new('2 years', 2.years).freeze,
+    expirescustom60:   ExpiresTypeData.new('60 days', 60.days).freeze,
+    expirescustom90:   ExpiresTypeData.new('90 days', 90.days).freeze
+  }.freeze
+
+  # An expiration date is an actually two things:
+  # * a date (returned from ActiveRecord as an ActiveSupport::TimeWithZone,
+  #   which stringifies nicely into something Date.parse can deal with)
+  # * A symbol representing the expiration policy
+  #
+  # @param [String, #to_datetime, #to_date] date String representation of the date.
+  #   This is always truncated to just the date (see  https://hathitrust.slack.com/archives/DKV93G37T/p1576770049002400)
+  # @param [String,Symbol] type The expires_type to use
+  def initialize(date, type = :expiresannually)
+    @date         = if date.respond_to? :to_date
+                      date.to_date
+                    else
+                      Time.zone.parse(date.to_s).to_date
+                    end.freeze
+    @expires_type = type.to_sym
+  end
+
+  def to_date
+    @date.to_date
+  end
+
+  ### NOTE ###
+  #  Asked Melissa if we'd ever need granularity beyond the date level,
+  #  and she says no. https://hathitrust.slack.com/archives/DKV93G37T/p1576770049002400
+  # Long version of the date string
+  # @return [String] date string
+  # def database_string
+  #   @date.to_s(:db)
+  # end
+
+  # Short version of the date string
+  # @return [String] YYYY-MM-DD
+  def short_string
+    @date.strftime '%Y-%m-%d'
+  end
+
+  alias to_s short_string
+
+  # How many days until expiration?
+  # @return [Number] days until expiration
+  def days_until_expiration
+    (@date.to_date - Date.today).to_i
+  end
+
+  # Is this person expiring "soon" (based on the config)?
+  # @return [Boolean]
+  def expiring_soon?
+    days_until_expiration.between? 0, (Otis.config&.expires_soon_in_days || 30)
+  end
+
+  # Are we, in fact, already expired?
+  # @return [Boolean]
+  def expired?
+    days_until_expiration.negative?
+  end
+
+  # What text describes the extension period?
+  # @return [String] A human readable extension period (.e.g, "1 year")
+  def extension_period_text
+    EXPIRES_TYPE[@expires_type].label
+  end
+
+  # The date if we advance the expiration date  by the default amount
+  # @return [ActiveSupport::TimeWithZone] The new expiration date
+  def default_extension_date
+    @date + EXPIRES_TYPE[@expires_type].duration
+  rescue NoMethodError => e
+    raise e
+  end
+
+  # For comparisons, just check the date
+  # @param [#to_date, String] other Any object that can turn itself into a date,
+  #  or a string that can be parsed by Time.zone.parse
+  # @return [Integer] Normal <=> return indicating (in)equality of the dates only
+  def <=>(other)
+    if other.respond_to?(:to_date)
+      to_date <=> other.to_date
+    else
+      to_date <=> Time.zone.parse(other.to_s).to_date
+    end
+  end
+end

--- a/app/models/ht_user.rb
+++ b/app/models/ht_user.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'expiration_date'
+require 'forwardable'
+
 class HTUser < ApplicationRecord
   self.primary_key = 'email'
   belongs_to :ht_institution, foreign_key: :identity_provider, primary_key: :entityID
@@ -7,7 +10,7 @@ class HTUser < ApplicationRecord
   validates :iprestrict, presence: true, unless: :mfa
   validates :iprestrict, allow_nil: true,
                          format: {with: /\A(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\z/,
-                                  message: 'requires a valid IPv4 address' }
+                                  message: 'requires a valid IPv4 address'}
 
   validates :email, presence: true
   validates :userid, presence: true
@@ -18,9 +21,9 @@ class HTUser < ApplicationRecord
   scope :expired, -> { where('expires <= CURRENT_TIMESTAMP') }
 
   validate do
-    DateTime.parse(expires.to_s)
+    Time.zone.parse(expires.to_s)
   rescue StandardError
-    errors[:expires] << 'must be a valid timestamp'
+    errors[:expires] << "must be a valid timestamp, not #{expires}"
   end
 
   HUMANIZED_ATTRIBUTES = {
@@ -29,6 +32,33 @@ class HTUser < ApplicationRecord
 
   def self.human_attribute_name(attr, options = {})
     HUMANIZED_ATTRIBUTES[attr.to_sym] || super
+  end
+
+  # Grab an expiration_date object. And yes, the long method name is deserved.
+  # rubocop:disable
+  def construct_and_set_expiration_date
+    @expiration_date = ExpirationDate.new(self[:expires], self[:expire_type])
+  end
+  # rubocop:enable
+
+  # Update expiration_date only if it already exists, because factorybot updates
+  # stuff in order and we might not have the expire_type yet
+  # This seems like a dumb way to deal with the testing framework, but I'm
+  # not sure what else to do. Maybe just reorder the factory definition
+  # and put a note in there?
+  def expires=(val)
+    self[:expires] = val
+    @expiration_date = expiration_date(:force_update) unless @expiration_date.nil?
+    expires
+  end
+
+  def expiration_date(force_update = false)
+    if force_update || @expiration_date.nil?
+      type                = expire_type
+      date                = expires
+      @expiration_date = ExpirationDate.new(date, type.to_s)
+    end
+    @expiration_date
   end
 
   # iprestrict is in the database as an escaped IPv4 regex e.g., ^127\.0\.0\.1$
@@ -46,26 +76,31 @@ class HTUser < ApplicationRecord
     write_attribute(:iprestrict, val)
   end
 
+  ## Forward some stuff to @expiration_date
+
   # Display datetime without UTC suffix or just date
-  def expires(short: false)
-    short ? self[:expires]&.strftime('%Y-%m-%d') : self[:expires]&.to_s(:db)
+  def expires_string
+    expiration_date.to_s
   end
 
   # How many days until expiration?
   # @return [Number] days until expiration
   def days_until_expiration
-    (self[:expires].to_date - Date.today).to_i
+    expiration_date.days_until_expiration
   end
 
   # Is this person expiring "soon" (based on the config)?
   # @return [Boolean]
   def expiring_soon?
-    days_until_expiration.between? 0, (Otis.config&.expires_soon_in_days || 30)
+    expiration_date.expiring_soon?
   end
 
-  # Is this person, in fact, expired?
   def expired?
-    days_until_expiration.negative?
+    expiration_date.expired?
+  end
+
+  def extend_by_default_period!
+    self.expires = expiration_date.default_extension_date.to_date
   end
 
   def institution

--- a/app/views/ht_users/edit.html.erb
+++ b/app/views/ht_users/edit.html.erb
@@ -5,27 +5,37 @@
 
   <%= form_with(model: @user, local: true) do |form| %>
 
-    <% expired_text = @user.expired? ? "Expired" : "Expires"
-       expires_class = @user.expiring_soon? ? "expiring-soon" : ""
+    <% ed = @user.expiration_date
+       expired_text = ed.expired? ? "Expired" : "Expires"
+       expires_class = ed.expiring_soon? ? "expiring-soon" : ""
     %>
 
     <div class="col-2">
       <dl class="dl-horizontal">
         <%= form.hidden_field :userid %>
 
-        <dt>E-mail:</dt> <dd><%= @user.email %></dd>
-        <dt>Display Name:</dt> <dd><%= @user.displayname %></dd>
-        <dt>User ID:</dt> <dd><%= @user.userid %></dd>
-        <dt>Activity Contact:</dt> <dd><%= @user.activitycontact %></dd>
+        <dt>E-mail:</dt>
+        <dd><%= @user.email %></dd>
+        <dt>Display Name:</dt>
+        <dd><%= @user.displayname %></dd>
+        <dt>User ID:</dt>
+        <dd><%= @user.userid %></dd>
+        <dt>Activity Contact:</dt>
+        <dd><%= @user.activitycontact %></dd>
         <dt><%= form.label :approver %></dt>
         <dd><%= form.text_field :approver, size: 40 %></dd>
-        <dt>Authorizer:</dt> <dd><%= @user.authorizer %></dd>
-        <dt>User Type:</dt> <dd><%= @user.usertype %></dd>
-        <dt>Role:</dt> <dd><%= @user.role %></dd>
-        <dt>Access:</dt> <dd><%= @user.access %></dd>
-        <dt>Expire Type:</dt> <dd><%= @user.expire_type %></dd>
+        <dt>Authorizer:</dt>
+        <dd><%= @user.authorizer %></dd>
+        <dt>User Type:</dt>
+        <dd><%= @user.usertype %></dd>
+        <dt>Role:</dt>
+        <dd><%= @user.role %></dd>
+        <dt>Access:</dt>
+        <dd><%= @user.access %></dd>
+        <dt>Expire Type:</dt>
+        <dd><%= @user.expire_type %></dd>
         <dt><%= form.label :expires, expired_text %></dt>
-        <dd><%= form.text_field :expires, value: @user.expires(short: true), size: 12, id: :expires_field, class: expires_class %>
+        <dd><%= form.text_field :expires, value: @user.expires_string, size: 12, id: :expires_field, class: expires_class %>
           <% unless @user.expired? %>
             <%= form.button "Expire Now", type: :button, onclick: "$('#expires_field').val('#{Time.current.to_s(:db)}');" %>
           <% end %>
@@ -33,9 +43,12 @@
 
         <dt><%= form.label :iprestrict %></dt>
         <dd><%= form.text_field :iprestrict, size: 40 %></dd>
-        <dt>Multi-Factor?:</dt> <dd><%= @user.mfa %></dd>
-        <dt>Identity Provider:</dt> <dd><%= @user.identity_provider %></dd>
-        <dt>Institution:</dt> <dd><%= @user.institution %></dd>
+        <dt>Multi-Factor?:</dt>
+        <dd><%= @user.mfa %></dd>
+        <dt>Identity Provider:</dt>
+        <dd><%= @user.identity_provider %></dd>
+        <dt>Institution:</dt>
+        <dd><%= @user.institution %></dd>
       </dl>
     </div>
 

--- a/app/views/ht_users/index.html.erb
+++ b/app/views/ht_users/index.html.erb
@@ -29,7 +29,7 @@
         <td><%= u.role %></td>
         <td><%= u.institution %></td>
         <td class="text-nowrap <%= u.expiring_soon? ? "bg-danger" : '' %>">
-          <%= u.expires(short: true) %>
+          <%= u.expires_string %>
           <% if u.expiring_soon? %>
             <div class="text-danger">
               <span class="expiring-soon text-danger"><%= u.days_until_expiration %>
@@ -65,7 +65,7 @@
         <td><%= u.displayname %></td>
         <td><%= u.role %></td>
         <td><%= u.institution %></td>
-        <td class="text-nowrap"><%= u.expires(short: true) %></td>
+        <td><%= u.expires_string %></td>
         <td><%= u.iprestrict %></td>
         <td>
           <%= raw u[:mfa] ? '<i class="glyphicon glyphicon-ok"></i>' : '' %>

--- a/app/views/ht_users/show.html.erb
+++ b/app/views/ht_users/show.html.erb
@@ -1,11 +1,13 @@
 <div id="maincontent" class="row">
   <h1><%= @user.displayname %></h1>
 
-  <%= render 'shared/flash_message' %>
 
   <% expired_text = @user.expired? ? "Expired" : "Expires"
      expires_class = @user.expiring_soon? ? "expiring-soon" : ""
   %>
+
+  <%= render 'shared/flash_message' %>
+
   <div class="col-sm-6">
     <dl class="dl-horizontal">
       <dt>E-mail:</dt> <dd><%= @user.email %></dd>
@@ -18,7 +20,7 @@
       <dt>Role:</dt> <dd><%= @user.role %></dd>
       <dt>Access:</dt> <dd><%= @user.access %></dd>
       <dt>Expire Type:</dt> <dd><%= @user.expire_type %></dd>
-      <dt><%= expired_text %></dt> <dd class="<%= expires_class %>"><%= @user.expires %></dd>
+      <dt><%= expired_text %></dt> <dd class="<%= expires_class %>"><%= @user.expires_string %></dd>
       <dt>IP Restriction:</dt> <dd><%= @user.iprestrict %></dd>
       <dt>Multi-Factor?:</dt> <dd><%= @user.mfa %></dd>
       <dt>Identity Provider:</dt> <dd><%= @user.identity_provider %></dd>

--- a/bin/bundle
+++ b/bin/bundle
@@ -1,3 +1,0 @@
-#!/usr/bin/env ruby
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
-load Gem.bin_path('bundler', 'bundle')

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
+require 'active_support/time'
+
 FactoryBot.define do
-  factory :ht_user do
+  factory :ht_user, class: HTUser do
     sequence(:userid) { |n| "#{n}#{Faker::Internet.email}" }
     email { Faker::Internet.email }
+    expire_type { ExpirationDate::EXPIRES_TYPE.keys.sample.to_s }
     expires { Faker::Time.forward }
     iprestrict { Faker::Internet.ip_v4_address }
     ht_institution

--- a/test/models/expiration_date_test.rb
+++ b/test/models/expiration_date_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ExpirationDateTest < ActiveSupport::TestCase
+  def setup
+    @jan1      = ExpirationDate.new('2020-01-01 11:11:11', :expiresannually)
+    @plus10    = ExpirationDate.new((Date.today + 10), :expiresannually)
+    @minus10   = ExpirationDate.new((Date.today - 10), :expiresannually)
+    @yearsaway = ExpirationDate.new((Date.today + 700), :expiresannuyally)
+
+    @annual   = @jan1
+    @custom60 = ExpirationDate.new(Date.today, :expirescustom60)
+  end
+
+  test 'Create a simple object and get back strings' do
+    assert_equal '2020-01-01', @jan1.short_string
+    assert_equal '2020-01-01', @jan1.to_s
+  end
+
+  test 'Determine days until expiration' do
+    assert_equal 10, @plus10.days_until_expiration
+  end
+
+  test 'Boolean tests about expiration' do
+    assert @plus10.expiring_soon?
+    assert_not @plus10.expired?
+    assert @minus10.expired?
+    assert_not @yearsaway.expiring_soon?
+    assert_not @minus10.expiring_soon?
+  end
+
+  test 'Expiration extension' do
+    assert_equal Date.parse('2021-01-01'), @annual.default_extension_date.to_date
+    assert_equal Date.today + 60, @custom60.default_extension_date.to_date
+    assert_equal '1 year', @annual.extension_period_text
+    assert_equal '60 days', @custom60.extension_period_text
+  end
+
+  test 'Equality' do
+    eq1 = ExpirationDate.new('2019-01-01', :expiresannually)
+    eq2 = ExpirationDate.new('2019-01-01', :expiresannually)
+    eq3 = ExpirationDate.new('2019-01-01', :expirescustom60)
+    neq = ExpirationDate.new('2022-02-02', :expiresannually)
+
+    assert_equal(eq1, eq2)
+    assert_equal(eq1, eq3)
+    assert_not_equal(eq1, neq)
+  end
+end

--- a/test/models/ht_user_test.rb
+++ b/test/models/ht_user_test.rb
@@ -27,11 +27,6 @@ class HTUserTest < ActiveSupport::TestCase
     assert_equal user.iprestrict, '127.0.0.1'
   end
 
-  test 'expires suppresses UTC suffix' do
-    user = build(:ht_user)
-    assert_no_match(/UTC$/, user.expires.to_s)
-  end
-
   test 'expires validation rejects various bogative timestamps' do
     user = build(:ht_user, expires: '2020-21-01 00:00:00')
     assert_not user.valid?

--- a/test/models/ht_user_test.rb
+++ b/test/models/ht_user_test.rb
@@ -29,7 +29,7 @@ class HTUserTest < ActiveSupport::TestCase
 
   test 'expires suppresses UTC suffix' do
     user = build(:ht_user)
-    assert_no_match(/UTC$/, user.expires)
+    assert_no_match(/UTC$/, user.expires.to_s)
   end
 
   test 'expires validation rejects various bogative timestamps' do
@@ -82,6 +82,23 @@ class HTUserExpiringSoon < ActiveSupport::TestCase
     assert(@expiring_user.expiring_soon?)
     assert_not(@expired_user.expiring_soon?)
     assert_not(@safe_user.expiring_soon?)
+  end
+
+  test 'Expiration date can be set via #expires' do
+    user = build(:ht_user, expires: Date.today - 10)
+    assert user.expired?
+    assert user.expiration_date.expired?
+
+    user.expires = Date.today + 100
+    assert_not user.expired?
+    assert_not user.expiration_date.expired?
+  end
+
+  test 'Extend date by default period' do
+    initial_date = '2019-01-01'
+    u1 = build(:ht_user, expires: initial_date, expire_type: 'expirescustom60')
+    u1.extend_by_default_period!
+    assert_equal Date.parse(initial_date) + 60, u1.expires.to_date
   end
 end
 


### PR DESCRIPTION
(This touches a *lot* of files, but only `app/models/expiration_date.rb` 
and the associated test file should need more than a cursory review)

The expiration date is being manipulated enough that
it's worth breaking out into its own class that
can compute things (e.g., whether it's expired,
how long until it expires, etc.)

An expiration date is both the actual 
date and the expires type (e.g, "expiresannually"). Expiration dates are
*compared* only by date.

Expiration dates are always dates only; the
time is thrown away. A quick question to Melissa
verified that this is ok.
https://hathitrust.slack.com/archives/DKV93G37T/p1576770049002400

The HTUser object now creates a new expiration date
object on creation and whenever `expires` is set and
forwards appropriate methods to it. The
expiration date object itself is read-only.