### PR TITLE
Addresses HT-2007 iprestrict should be allowed to be NULL if MFA = true

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,10 @@ Metrics/AbcSize:
 Metrics/LineLength:
   Enabled: false
 
+Metrics/ClassLength:
+  Exclude:
+    - 'test/**/*'
+
 Style/ClassAndModuleChildren:
   Enabled: false
 

--- a/app/models/ht_user.rb
+++ b/app/models/ht_user.rb
@@ -4,7 +4,8 @@ class HTUser < ApplicationRecord
   self.primary_key = 'email'
   belongs_to :ht_institution, foreign_key: :identity_provider, primary_key: :entityID
 
-  validates :iprestrict, presence: true, unless: :mfa,
+  validates :iprestrict, presence: true, unless: :mfa
+  validates :iprestrict, allow_nil: true,
                          format: {with: /\A(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\z/,
                                   message: 'requires a valid IPv4 address' }
 
@@ -40,6 +41,7 @@ class HTUser < ApplicationRecord
   end
 
   def iprestrict=(val)
+    val = nil if val.blank?
     val = '^' + val.strip.gsub('.', '\.') + '$' if val.present?
     write_attribute(:iprestrict, val)
   end

--- a/app/models/ht_user.rb
+++ b/app/models/ht_user.rb
@@ -4,7 +4,7 @@ class HTUser < ApplicationRecord
   self.primary_key = 'email'
   belongs_to :ht_institution, foreign_key: :identity_provider, primary_key: :entityID
 
-  validates :iprestrict, presence: true,
+  validates :iprestrict, presence: true, unless: :mfa,
                          format: {with: /\A(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\z/,
                                   message: 'requires a valid IPv4 address' }
 
@@ -40,9 +40,8 @@ class HTUser < ApplicationRecord
   end
 
   def iprestrict=(val)
-    val = val.strip
-    escaped = '^' + val.gsub('.', '\.') + '$'
-    write_attribute(:iprestrict, escaped)
+    val = '^' + val.strip.gsub('.', '\.') + '$' if val.present?
+    write_attribute(:iprestrict, val)
   end
 
   # Display datetime without UTC suffix or just date

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -26,10 +26,10 @@ def create_ht_user(expires:)
     access: %w[total normal].sample,
     expires: expires,
     expire_type: %w[expiresannually expiresbiannually expirescustom90 expirescustom60].sample,
-    mfa: 0,
+    mfa: [false, true].sample,
     identity_provider: HTInstitution.all.sample.entityID
   )
-  u.iprestrict = Faker::Internet.ip_v4_address
+  u.iprestrict = Faker::Internet.ip_v4_address unless u.mfa
   u.save
 end
 # rubocop:enable Metrics/MethodLength

--- a/test/controllers/ht_users_controller_test.rb
+++ b/test/controllers/ht_users_controller_test.rb
@@ -78,6 +78,14 @@ class HTUsersControllerTest < ActionDispatch::IntegrationTest
     assert_match '127.0.0.2', @response.body
   end
 
+  test 'updating expiration for mfa user retains nil iprestrict' do
+    user = create(:ht_user, mfa: true, iprestrict: nil)
+    sign_in!
+    patch ht_user_url user, params: {'ht_user' => {'iprestrict' => '', 'expires' => Date.today.to_s}}
+    assert_redirected_to ht_user_path(user.email)
+    assert_nil HTUser.find(user.email)[:iprestrict]
+  end
+
   test 'active users separated from expired users' do
     active  = create(:ht_user, :active)
     expired = create(:ht_user, :expired)

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -13,6 +13,11 @@ FactoryBot.define do
     trait :expired do
       expires { Faker::Time.backward }
     end
+
+    factory :ht_user_mfa do
+      mfa { true }
+      iprestrict { nil }
+    end
   end
 
   factory :ht_institution do

--- a/test/models/ht_user_test.rb
+++ b/test/models/ht_user_test.rb
@@ -84,3 +84,15 @@ class HTUserExpiringSoon < ActiveSupport::TestCase
     assert_not(@safe_user.expiring_soon?)
   end
 end
+
+class HTUserMFA < ActiveSupport::TestCase
+  def setup
+    @mfa_user = build(:ht_user_mfa)
+  end
+
+  test 'User with MFA and no iprestrict is valid' do
+    assert_equal(@mfa_user.mfa, true)
+    assert_nil @mfa_user.iprestrict
+    assert @mfa_user.valid?
+  end
+end


### PR DESCRIPTION
Main change is the iprestrict validation being turned off if mfa is true. Changes to DB seeds and test factory to create mfa = true records.

Minor change to iprestrict= method to allow setting to nil, not sure if that is something that would happen in a production environment but I needed it (apparently) for the ht_user_mfa factory.