### PR TITLE
Fix HTUser show page crash on nil iprestrict.

### DIFF
--- a/app/views/ht_users/show.html.erb
+++ b/app/views/ht_users/show.html.erb
@@ -21,7 +21,7 @@
       <dt>Access:</dt> <dd><%= @user.access %></dd>
       <dt>Expire Type:</dt> <dd><%= @user.expire_type %></dd>
       <dt><%= expired_text %></dt> <dd class="<%= expires_class %>"><%= @user.expires_string %></dd>
-      <dt>IP Restriction:</dt> <dd><%= @user.iprestrict.join(', ') %></dd>
+      <dt>IP Restriction:</dt> <dd><%= @user.iprestrict&.join(', ') %></dd>
       <dt>Multi-Factor?:</dt> <dd><%= raw @user.mfa ? '<i class="glyphicon glyphicon-ok"></i>' : '' %></dd>
       <dt>Identity Provider:</dt> <dd><%= @user.identity_provider %></dd>
       <dt>Institution:</dt> <dd><%= @user.institution %></dd>

--- a/test/controllers/ht_users_controller_test.rb
+++ b/test/controllers/ht_users_controller_test.rb
@@ -42,11 +42,21 @@ class HTUsersControllerTest < ActionDispatch::IntegrationTest
 
   test 'should get show page' do
     sign_in!
-    get ht_users_url @user1
+    get ht_user_url @user1
     assert_response :success
-    assert_not_nil assigns(:users)
+    assert_equal 'show', @controller.action_name
+    assert_not_nil assigns(:user)
     assert_match @user1.email, @response.body
     assert_match @user1.institution, @response.body
+  end
+
+  test 'should get show page with no iprestrict' do
+    sign_in!
+    user = create(:ht_user_mfa)
+    assert_nil user.iprestrict
+    get ht_user_url user
+    assert_response :success
+    assert_equal 'show', @controller.action_name
   end
 
   test 'should get edit page' do


### PR DESCRIPTION
Fix -- and fixed test -- for a nil iprestrict crashing HTUsers show page due to non-use of safe nav operator (and/or iprestrict returning nil instead of empty array but that's an issue for another day).