### PR TITLE
HT-1472 user approval status visible.

### DIFF
--- a/app/controllers/approval_controller.rb
+++ b/app/controllers/approval_controller.rb
@@ -24,7 +24,6 @@ class ApprovalController < ApplicationController
   def approve
     @req.received = Time.now
     @req.save!
-    @user.renew
     log
   end
 

--- a/app/controllers/ht_users_controller.rb
+++ b/app/controllers/ht_users_controller.rb
@@ -7,11 +7,13 @@ class HTUsersController < ApplicationController
 
   def index
     if params[:email]
-      @users = HTUser.joins(:ht_institution).where('email LIKE ?', "%#{params[:email]}%").order(:userid)
-      flash.now[:alert] = "No results for '#{params[:email]}'" if @users.empty?
+      users = HTUser.joins(:ht_institution).where('email LIKE ?', "%#{params[:email]}%").order(:userid)
+      flash.now[:alert] = "No results for '#{params[:email]}'" if users.empty?
     else
-      @users = HTUser.joins(:ht_institution).order('ht_institutions.name')
+      users = HTUser.joins(:ht_institution).order('ht_institutions.name')
     end
+    @users = users.active.map { |u| HTUserPresenter.new(u) }
+    @expired_users = users.expired.map { |u| HTUserPresenter.new(u) }
   end
 
   def update
@@ -28,7 +30,7 @@ class HTUsersController < ApplicationController
   private
 
   def fetch_user
-    @user = HTUser.joins(:ht_institution).find(params[:id])
+    @user = HTUserPresenter.new(HTUser.joins(:ht_institution).find(params[:id]))
   end
 
   def user_params

--- a/app/presenters/ht_approval_request_presenter.rb
+++ b/app/presenters/ht_approval_request_presenter.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
 class HTApprovalRequestPresenter
-  def initialize(req)
-    @req = req
-  end
-
-  def badge
+  def self.badge_for(obj)
     @badges ||= {
       unsent: '<span class="label label-warning">Unsent</span>',
       sent: '<span class="label label-default">Sent</span>',
@@ -13,8 +9,8 @@ class HTApprovalRequestPresenter
       approved: '<span class="label label-info">Approved</span>',
       renewed: '<span class="label label-success">Renewed</span>'
     }
-    return '' if @req.nil?
+    return '' if obj.nil?
 
-    @badges[@req.renewal_state]&.html_safe
+    @badges[obj.renewal_state]&.html_safe
   end
 end

--- a/app/presenters/ht_approval_request_presenter.rb
+++ b/app/presenters/ht_approval_request_presenter.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class HTApprovalRequestPresenter
+  def initialize(req)
+    @req = req
+  end
+
+  def badge
+    @badges ||= {
+      unsent: '<span class="label label-warning">Unsent</span>',
+      sent: '<span class="label label-default">Sent</span>',
+      expired: '<span class="label label-danger">Expired</span>',
+      approved: '<span class="label label-info">Approved</span>',
+      renewed: '<span class="label label-success">Renewed</span>'
+    }
+    return '' if @req.nil?
+
+    @badges[@req.renewal_state]&.html_safe
+  end
+end

--- a/app/presenters/ht_user_presenter.rb
+++ b/app/presenters/ht_user_presenter.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class HTUserPresenter < SimpleDelegator
+  def init(user)
+    @user = user
+  end
+
+  def badge
+    HTApprovalRequestPresenter.badge_for(approval_request)
+  end
+
+  private
+
+  def approval_request
+    @approval_request ||= HTApprovalRequest.not_renewed_for_user(email).first
+  end
+end

--- a/app/views/ht_approval_requests/edit.html.erb
+++ b/app/views/ht_approval_requests/edit.html.erb
@@ -9,8 +9,7 @@
     <% @reqs.each do |req| %>
       <li class="list-group-item">
         <%= req.userid %></dt>
-        <% req_presenter = HTApprovalRequestPresenter.new(req) %>
-        <%= req_presenter.badge %>
+        <%= HTApprovalRequestPresenter.badge_for(req) %>
       </li>
     <% end %>
     </ul>
@@ -22,9 +21,9 @@
       </div>
     </div>
     <% counts = controller.status_counts %>
-    <% if counts[:unsent].positive? || counts[:expired].positive? %>
+    <% if counts[:unsent]&.positive? || counts[:expired]&.positive? %>
       <%= form_tag ht_approval_request_path, method: :put do %>
-        <% label = counts[:expired].positive? ? 'RESEND' : 'SEND' %>
+        <% label = counts[:expired]&.positive? ? 'RESEND' : 'SEND' %>
         <%= submit_tag label, class: 'btn btn-primary' %>
         <%= link_to 'Cancel', ht_approval_request_path(@reqs[0].approver), class: 'btn btn-primary' %>
       <% end %>

--- a/app/views/ht_approval_requests/edit.html.erb
+++ b/app/views/ht_approval_requests/edit.html.erb
@@ -1,20 +1,33 @@
 <div id="maincontent" class="row">
-
-  <h1>Approval Request for <%= params[:id] %>
-    <% if controller.all_sent? %>
-      <span class="label label-success">Sent</span>
-    <% else %>
-      <span class="label label-info">Not Sent</span>
-    <% end %>
-  </h1>
+  <h1>Approval Requests for <%= params[:id] %></h1>
 
   <%= render 'shared/flash_message' %>
-
-  <%= render 'shared/approval_request_email' %>
-
-  <% unless controller.all_sent? %>
-    <%= form_tag ht_approval_request_path, method: :put do %>
-      <%= submit_tag 'SEND', class: 'btn btn-primary' %>
+  <% if @reqs.count == 0 %>
+    There are no outstanding requests for this approver.
+  <% else %>
+  <ul class="list-group">
+    <% @reqs.each do |req| %>
+      <li class="list-group-item">
+        <%= req.userid %></dt>
+        <% req_presenter = HTApprovalRequestPresenter.new(req) %>
+        <%= req_presenter.badge %>
+      </li>
+    <% end %>
+    </ul>
+    <!-- MAIL PREVIEW -->
+    <div class="panel panel-default">
+      <div class="panel-heading">E-mail Preview</div>
+      <div class="panel-body">
+        <%= render 'shared/approval_request_email' %>
+      </div>
+    </div>
+    <% counts = controller.status_counts %>
+    <% if counts[:unsent].positive? || counts[:expired].positive? %>
+      <%= form_tag ht_approval_request_path, method: :put do %>
+        <% label = counts[:expired].positive? ? 'RESEND' : 'SEND' %>
+        <%= submit_tag label, class: 'btn btn-primary' %>
+        <%= link_to 'Cancel', ht_approval_request_path(@reqs[0].approver), class: 'btn btn-primary' %>
+      <% end %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/ht_approval_requests/index.html.erb
+++ b/app/views/ht_approval_requests/index.html.erb
@@ -9,6 +9,7 @@
     <tr>
       <th data-sortable="true">Approver</th>
       <th data-sortable="true">User</th>
+      <th data-sortable="ttue">Status</th>
       <th data-sortable="true">Sent</th>
       <th data-sortable="true">Received</th>
     </tr>
@@ -16,8 +17,18 @@
 
     <% @reqs.each do |req| %>
       <tr <%= raw @added.include?(req.userid) ? 'class="success"' : '' %>>
-        <td><%= link_to req.approver, ht_approval_request_path(req.approver) %></td>
+        <td>
+          <% if HTApprovalRequest.where(approver: req.approver, received: nil).count.positive? %>
+            <%= link_to req.approver, ht_approval_request_path(req.approver) %>
+          <% else %>
+            <%= req.approver %>
+          <% end %>
+        </td>
         <td><%= link_to req.userid, ht_user_path(req.userid) %></td>
+        <td>
+          <% req_presenter = HTApprovalRequestPresenter.new(req) %>
+          <%= req_presenter.badge %>
+        </td>
         <td><%= req.sent(short: true) %></td>
         <td><%= req.received(short: true) %></td>
       </tr>

--- a/app/views/ht_approval_requests/index.html.erb
+++ b/app/views/ht_approval_requests/index.html.erb
@@ -9,7 +9,6 @@
     <tr>
       <th data-sortable="true">Approver</th>
       <th data-sortable="true">User</th>
-      <th data-sortable="ttue">Status</th>
       <th data-sortable="true">Sent</th>
       <th data-sortable="true">Received</th>
     </tr>
@@ -18,7 +17,7 @@
     <% @reqs.each do |req| %>
       <tr <%= raw @added.include?(req.userid) ? 'class="success"' : '' %>>
         <td>
-          <% if HTApprovalRequest.where(approver: req.approver, received: nil).count.positive? %>
+          <% if HTApprovalRequest.not_renewed_for_approver(req.approver).count.positive? %>
             <%= link_to req.approver, ht_approval_request_path(req.approver) %>
           <% else %>
             <%= req.approver %>
@@ -26,10 +25,11 @@
         </td>
         <td><%= link_to req.userid, ht_user_path(req.userid) %></td>
         <td>
-          <% req_presenter = HTApprovalRequestPresenter.new(req) %>
-          <%= req_presenter.badge %>
+          <%= req.sent(short: true) %>
+          <% if req.renewal_state == :expired %>
+            <span class="label label-danger">Expired</span>
+          <% end %>
         </td>
-        <td><%= req.sent(short: true) %></td>
         <td><%= req.received(short: true) %></td>
       </tr>
     <% end %>

--- a/app/views/ht_approval_requests/show.html.erb
+++ b/app/views/ht_approval_requests/show.html.erb
@@ -1,20 +1,19 @@
 <div id="maincontent" class="row">
-
-  <h1>Approval Request for <%= params[:id] %>
-    <% if controller.all_sent? %>
-      <span class="label label-success">Sent</span>
-    <% else %>
-      <span class="label label-info">Not Sent</span>
-    <% end %>
-  </h1>
+  <h1>Approval Requests for <%= params[:id] %></h1>
 
   <%= render 'shared/flash_message' %>
-
-  <%= render 'shared/approval_request_email' %>
-
-  <% unless controller.all_sent? %>
-    <%= form_tag ht_approval_request_path, method: :put do %>
-      <%= submit_tag 'SEND', class: 'btn btn-primary' %>
+  <% if @reqs.count == 0 %>
+    There are no outstanding requests for this approver.
+  <% else %>
+    <ul class="list-group">
+    <% @reqs.each do |req| %>
+      <li class="list-group-item">
+        <%= req.userid %></dt>
+        <% req_presenter = HTApprovalRequestPresenter.new(req) %>
+        <%= req_presenter.badge %>
+      </li>
     <% end %>
+    </ul>
+    <%= link_to 'Edit', edit_ht_approval_request_path, class: 'btn btn-primary' %>
   <% end %>
 </div>

--- a/app/views/ht_approval_requests/show.html.erb
+++ b/app/views/ht_approval_requests/show.html.erb
@@ -9,8 +9,7 @@
     <% @reqs.each do |req| %>
       <li class="list-group-item">
         <%= req.userid %></dt>
-        <% req_presenter = HTApprovalRequestPresenter.new(req) %>
-        <%= req_presenter.badge %>
+        <%= HTApprovalRequestPresenter.badge_for(req) %>
       </li>
     <% end %>
     </ul>

--- a/app/views/ht_users/edit.html.erb
+++ b/app/views/ht_users/edit.html.erb
@@ -60,7 +60,8 @@
             <%= form.button "Expire Now", type: :button, onclick: "$('#expires_field').val('#{Time.current.to_s(:db)}');" %>
           <% end %>
         </dd>
-
+        <dt>Renewal Status</dt>
+        <dd><%= @user.badge %></dd>
         <dt><%= form.label :iprestrict %></dt>
         <dd><%= form.text_field :iprestrict, value: @user.iprestrict&.join(', '), size: 40, id: :iprestrict_field, disabled: @user.mfa %>
           <p class="text-muted"><%= t('ht_user.edit.iprestrict_prompt') %></p>

--- a/app/views/ht_users/index.html.erb
+++ b/app/views/ht_users/index.html.erb
@@ -20,7 +20,7 @@
       <th data-sortable="true">Role</th>
       <th data-sortable="true">Institution</th>
       <th data-sortable="true">Expires</th>
-      <th data-sortable="true">Req?</th>
+      <th data-sortable="true">Renewal Status</th>
       <th>IP Restriction</th>
       <th data-sortable="true">MFA?</th>
     </tr>
@@ -47,7 +47,9 @@
           <% end %>
         </td>
         <td>
-          <%= raw u.approval_requested? ? '<i class="glyphicon glyphicon-ok"></i>' : '' %>
+          <% req = HTApprovalRequest.where(userid: u.email).first %>
+          <% req_presenter = HTApprovalRequestPresenter.new(req) %>
+          <%= req_presenter.badge %>
         </td>
         <td><%= u.iprestrict&.join(', ') %></td>
         <td>
@@ -56,7 +58,8 @@
       </tr>
     <% end %>
   </table>
-  <%= submit_tag 'Generate Approval Request(s)', name: 'submit_req' %>
+  <br/>
+  <%= submit_tag 'Generate Approval Requests', name: 'submit_req', class: 'btn btn-primary' %>
   <% end # form-with %>
 
   <h2>Expired Users</h2>

--- a/app/views/ht_users/index.html.erb
+++ b/app/views/ht_users/index.html.erb
@@ -26,7 +26,7 @@
     </tr>
     </thead>
 
-    <% @users.active.each do |u| %>
+    <% @users.each do |u| %>
       <tr>
         <td>
           <% unless u.approval_requested? %>
@@ -46,11 +46,7 @@
             </div>
           <% end %>
         </td>
-        <td>
-          <% req = HTApprovalRequest.where(userid: u.email).first %>
-          <% req_presenter = HTApprovalRequestPresenter.new(req) %>
-          <%= req_presenter.badge %>
-        </td>
+        <td><%= u.badge %></td>
         <td><%= u.iprestrict&.join(', ') %></td>
         <td>
           <%= raw u[:mfa] ? '<i class="glyphicon glyphicon-ok"></i>' : '' %>
@@ -76,7 +72,7 @@
       <th data-sortable="true">MFA?</th>
     </tr>
     </thead>
-    <% @users.expired.each do |u| %>
+    <% @expired_users.each do |u| %>
       <tr>
         <td><%= link_to u.email, ht_user_path(u) %></td>
         <td><%= u.displayname %></td>

--- a/app/views/ht_users/show.html.erb
+++ b/app/views/ht_users/show.html.erb
@@ -5,6 +5,8 @@
   <% expired_text = @user.expired? ? "Expired" : "Expires"
      expires_class = @user.expiring_soon? ? "expiring-soon" : ""
   %>
+  <% req = HTApprovalRequest.where(userid: @user.email).first %>
+  <% req_presenter = HTApprovalRequestPresenter.new(req) %>
 
   <%= render 'shared/flash_message' %>
 
@@ -21,17 +23,17 @@
       <dt>Access:</dt> <dd><%= @user.access %></dd>
       <dt>Expire Type:</dt> <dd><%= @user.expire_type %></dd>
       <dt><%= expired_text %></dt> <dd class="<%= expires_class %>"><%= @user.expires_string %></dd>
+      <dt>Renewal Status</dt> <dd><%= req_presenter.badge %></dd>
       <dt>IP Restriction:</dt> <dd><%= @user.iprestrict&.join(', ') %></dd>
       <dt>Multi-Factor?:</dt> <dd><%= raw @user.mfa ? '<i class="glyphicon glyphicon-ok"></i>' : '' %></dd>
       <dt>Identity Provider:</dt> <dd><%= @user.identity_provider %></dd>
       <dt>Institution:</dt> <dd><%= @user.institution %></dd>
-      <dt>Approval Requested?:</dt> <dd><%= @user.approval_requested? ? 'yes' : 'no' %>
       <hr/>
       <dt>Accesses</dt> <dd><%= @user.ht_count&.accesscount %></dd>
       <dt>Last Access</dt> <dd><%= @user.ht_count&.last_access&.to_s(:db) %></dd>
     </dl>
 
-    <%= link_to 'Edit', edit_ht_user_path %>
+    <%= link_to 'Edit', edit_ht_user_path, class: 'btn btn-primary' %>
   </div>
 </div>
 

--- a/app/views/ht_users/show.html.erb
+++ b/app/views/ht_users/show.html.erb
@@ -5,8 +5,6 @@
   <% expired_text = @user.expired? ? "Expired" : "Expires"
      expires_class = @user.expiring_soon? ? "expiring-soon" : ""
   %>
-  <% req = HTApprovalRequest.where(userid: @user.email).first %>
-  <% req_presenter = HTApprovalRequestPresenter.new(req) %>
 
   <%= render 'shared/flash_message' %>
 
@@ -23,7 +21,7 @@
       <dt>Access:</dt> <dd><%= @user.access %></dd>
       <dt>Expire Type:</dt> <dd><%= @user.expire_type %></dd>
       <dt><%= expired_text %></dt> <dd class="<%= expires_class %>"><%= @user.expires_string %></dd>
-      <dt>Renewal Status</dt> <dd><%= req_presenter.badge %></dd>
+      <dt>Renewal Status</dt> <dd><%= @user.badge %></dd>
       <dt>IP Restriction:</dt> <dd><%= @user.iprestrict&.join(', ') %></dd>
       <dt>Multi-Factor?:</dt> <dd><%= raw @user.mfa ? '<i class="glyphicon glyphicon-ok"></i>' : '' %></dd>
       <dt>Identity Provider:</dt> <dd><%= @user.identity_provider %></dd>

--- a/app/views/shared/_approval_request_email.html.erb
+++ b/app/views/shared/_approval_request_email.html.erb
@@ -17,7 +17,7 @@ information.<br/></p>
 
 <p>If you are no longer supervising the staff listed below or if you need to add
 or change staff with elevated access, please email
-<a href="mailto:feedback@issues.hathitrust.org">mailto:feedback@issues.hathitrust.org</a>.
+<a href="mailto:feedback@issues.hathitrust.org">feedback@issues.hathitrust.org</a>.
 
 <p>Thank you,<br/>HathiTrust User Support<br/></p>
 

--- a/app/views/shared/_approval_request_email.html.erb
+++ b/app/views/shared/_approval_request_email.html.erb
@@ -32,6 +32,7 @@ or change staff with elevated access, please email
 </tr>
   <% role_stars = {} %>
   <% @reqs.each do |req| %>
+    <% next unless req.mailable? %>
     <% u = req.ht_user %>
     <% unless role_stars[u.role] %>
       <% role_stars[u.role] = role_stars.count + 1 %>

--- a/app/views/shared/approval.html.erb
+++ b/app/views/shared/approval.html.erb
@@ -8,8 +8,9 @@
     <% elsif @already_used %>
       <strong>This link is no longer valid; it may have already been used.</strong>
     <% else %>
-      <p>Approval request found for <strong><%= @user.email %></strong> from <strong><%= @req.approver %></strong>.</p>
-      <p><strong><%= @user.email %></strong> renewed until <%= @user.expires_string %></p>
+      <p>Thank you.</p>
+      <p>Elevated access approval recorded for <strong><%= @user.email %></strong>
+         from <strong><%= @req.approver %></strong>.</p>
     <% end %>
   </body>
 </html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,7 @@ module Otis
     config.relative_url_root = Otis.config.relative_url_root
 
     config.action_mailer.default_url_options = { host: 'hathitrust.org' }
+    config.action_mailer.smtp_settings = { address: Otis.config.smtp_host }
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -16,3 +16,5 @@ shibboleth:
   sp:
     url: /useradmin/Shibboleth.sso
     entity_id: https://hathitrust.org/sp
+
+smtp_host: localhost

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -68,6 +68,7 @@ ActiveRecord::Schema.define(version: 0) do # rubocop:disable Metrics/BlockLength
     t.string :userid
     t.timestamp :sent
     t.timestamp :received
+    t.timestamp :renewed
     t.text :crypt
   end
 end

--- a/test/controllers/approval_controller_test.rb
+++ b/test/controllers/approval_controller_test.rb
@@ -15,7 +15,6 @@ class ApprovalControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'new', @controller.action_name
     assert_match @req.userid, @response.body
     assert_match @req.approver, @response.body
-    assert_in_delta(365, @user.reload.days_until_expiration, 1)
     assert_not_nil @req.reload.received
     assert_equal Date.parse(@req.reload.received).to_s, Date.today.to_s
   end

--- a/test/models/ht_approval_request_test.rb
+++ b/test/models/ht_approval_request_test.rb
@@ -19,8 +19,9 @@ class HTApprovalRequestTest < ActiveSupport::TestCase
     assert_not build(:ht_approval_request, sent: Time.now, received: Time.now - 1).valid?
   end
 
-  test 'a newly-sent request is not expired' do
+  test 'a newly-sent request is not expired and not renewed' do
     assert_not build(:ht_approval_request, sent: Time.now).expired?
+    assert_not build(:ht_approval_request, sent: Time.now).renewed.present?
   end
 
   test 'an old request is expired after a week' do
@@ -30,10 +31,12 @@ end
 
 class HTApprovalRequestUniquenessTest < ActiveSupport::TestCase
   def setup
-    @existing = create(:ht_approval_request, approver: 'nobody@example.com', userid: 'user@example.com')
+    @active = create(:ht_approval_request, approver: 'nobody@example.com', userid: 'active@example.com', renewed: nil)
+    @inactive = create(:ht_approval_request, approver: 'nobody@example.com', userid: 'inactive@example.com', renewed: Faker::Time.backward)
   end
 
-  test '#active returns only active users' do
-    assert_not build(:ht_approval_request, approver: 'somebody@example.com', userid: 'user@example.com').valid?
+  test 'user can have only one active approval request' do
+    assert_not build(:ht_approval_request, userid: 'active@example.com').valid?
+    assert build(:ht_approval_request, userid: 'inactove@example.com').valid?
   end
 end

--- a/test/presenters/ht_approval_request_presenter_test.rb
+++ b/test/presenters/ht_approval_request_presenter_test.rb
@@ -3,9 +3,8 @@
 require 'test_helper'
 
 class HTApprovalRequestPresenterTest < ActiveSupport::TestCase
-  test '#badge' do
+  test 'badge' do
     req = build(:ht_approval_request)
-    presenter = HTApprovalRequestPresenter.new(req)
-    assert_not_nil presenter.badge
+    assert_not_nil HTApprovalRequestPresenter.badge_for(req)
   end
 end

--- a/test/presenters/ht_approval_request_presenter_test.rb
+++ b/test/presenters/ht_approval_request_presenter_test.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class HTApprovalRequestPresenterTest < ActiveSupport::TestCase
+  test '#badge' do
+    req = build(:ht_approval_request)
+    presenter = HTApprovalRequestPresenter.new(req)
+    assert_not_nil presenter.badge
+  end
+end

--- a/test/presenters/ht_user_presenter_test.rb
+++ b/test/presenters/ht_user_presenter_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class HTUserPresenterTest < ActiveSupport::TestCase
+  test '#badge with approval request displays a badge' do
+    user = HTUserPresenter.new(create(:ht_user))
+    create(:ht_approval_request, userid: user.email)
+    assert_not_nil user.badge
+    assert_match 'span', user.badge
+  end
+
+  test '#badge without approval request is blank' do
+    user = HTUserPresenter.new(create(:ht_user))
+    assert_not_nil user.badge
+    assert_match '', user.badge
+  end
+end


### PR DESCRIPTION
Highlights:
- Walks back renewing users immediately on receipt of approval, in favor of adding a new field `renewed` to record the additional step of HathiTrust staff renewing manually or as a batch (to be implemented on a separate ticket).
- Badges galore!
- `ht_approval_request` show and edit page are no longer clones of each other. The latter is now the one with the e-mail preview. There's probably lots of fun stuff that can be done with the show page, right now it is pretty sparse.
- `db/seeds.rb` tries to generate some more interesting/realistic approval requests.
- Expired renewal requests can be resent.
- There's some nascent support for separating out the renewed requests as if they were no longer active.