### PR TITLE
Settle on Time.zone.now instead of Time.now across the board.

### DIFF
--- a/app/controllers/approval_controller.rb
+++ b/app/controllers/approval_controller.rb
@@ -22,7 +22,7 @@ class ApprovalController < ApplicationController
   private
 
   def approve
-    @req.received = Time.now
+    @req.received = Time.zone.now
     @req.save!
     @user.renew
     log

--- a/app/controllers/ht_approval_requests_controller.rb
+++ b/app/controllers/ht_approval_requests_controller.rb
@@ -16,7 +16,7 @@ class HTApprovalRequestsController < ApplicationController
     begin
       ApprovalRequestMailer.with(reqs: @reqs).approval_request_email.deliver_now
       @reqs.each do |req|
-        req.sent = Time.now
+        req.sent = Time.zone.now
         req.save!
       end
       flash[:notice] = 'Message sent'

--- a/test/controllers/approval_controller_test.rb
+++ b/test/controllers/approval_controller_test.rb
@@ -4,7 +4,7 @@ require 'test_helper'
 
 class ApprovalControllerTest < ActionDispatch::IntegrationTest
   def setup
-    @user = create(:ht_user, approver: 'nobody@example.com', expire_type: 'expiresannually', expires: Time.now)
+    @user = create(:ht_user, approver: 'nobody@example.com', expire_type: 'expiresannually', expires: Time.zone.now)
     @req = create(:ht_approval_request, userid: @user.email, approver: @user.approver, sent: Date.today - 1.day)
   end
 
@@ -17,7 +17,7 @@ class ApprovalControllerTest < ActionDispatch::IntegrationTest
     assert_match @req.approver, @response.body
     assert_in_delta(365, @user.reload.days_until_expiration, 1)
     assert_not_nil @req.reload.received
-    assert_equal Date.parse(@req.reload.received).to_s, Date.today.to_s
+    assert_equal Date.parse(@req.reload.received).to_s, Date.parse(Time.zone.now.to_s).to_s
   end
 
   test 'refuses to approve the same request a second time' do

--- a/test/models/ht_approval_request_test.rb
+++ b/test/models/ht_approval_request_test.rb
@@ -16,15 +16,15 @@ class HTApprovalRequestTest < ActiveSupport::TestCase
   end
 
   test 'sent must come before received' do
-    assert_not build(:ht_approval_request, sent: Time.now, received: Time.now - 1).valid?
+    assert_not build(:ht_approval_request, sent: Time.zone.now, received: Time.zone.now - 1).valid?
   end
 
   test 'a newly-sent request is not expired' do
-    assert_not build(:ht_approval_request, sent: Time.now).expired?
+    assert_not build(:ht_approval_request, sent: Time.zone.now).expired?
   end
 
   test 'an old request is expired after a week' do
-    assert build(:ht_approval_request, sent: (Time.now - 2.week)).expired?
+    assert build(:ht_approval_request, sent: (Time.zone.now - 2.week)).expired?
   end
 end
 

--- a/test/models/ht_user_test.rb
+++ b/test/models/ht_user_test.rb
@@ -151,11 +151,11 @@ end
 
 class HTUserRenewal < ActiveSupport::TestCase
   def setup
-    @expiresannually_user = build(:ht_user, expires: Time.now, expire_type: 'expiresannually')
-    @expiresbiannually_user = build(:ht_user, expires: Time.now, expire_type: 'expiresbiannually')
-    @expirescustom90_user = build(:ht_user, expires: Time.now, expire_type: 'expirescustom90')
-    @expirescustom60_user = build(:ht_user, expires: Time.now, expire_type: 'expirescustom60')
-    @unknown_user = build(:ht_user, expires: Time.now, expire_type: 'unknown')
+    @expiresannually_user = build(:ht_user, expires: Time.zone.now, expire_type: 'expiresannually')
+    @expiresbiannually_user = build(:ht_user, expires: Time.zone.now, expire_type: 'expiresbiannually')
+    @expirescustom90_user = build(:ht_user, expires: Time.zone.now, expire_type: 'expirescustom90')
+    @expirescustom60_user = build(:ht_user, expires: Time.zone.now, expire_type: 'expirescustom60')
+    @unknown_user = build(:ht_user, expires: Time.zone.now, expire_type: 'unknown')
   end
 
   test 'User expiresannually' do


### PR DESCRIPTION
This is an attempt to standardize on Time.zone.now etc since Time.now contributed to a test (approval_controller_test.rb) that failed at certain times of day due to a next-day GMT time getting stored in the database.