### PR TITLE
Redirect back to /login instead of eventual target page

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -7,7 +7,7 @@ class SessionController < ApplicationController
     if login
       redirect_back_or_to root_path
     else
-      default_login
+      redirect_to shib_login_url
     end
   end
 
@@ -40,11 +40,7 @@ class SessionController < ApplicationController
     head 403
   end
 
-  def default_login
-    redirect_to shib_login_url(request.base_url + (session[:return_to] || ''))
-  end
-
-  def shib_login_url(target)
+  def shib_login_url(target = request.original_url)
     URI("#{Otis.config.shibboleth.sp.url}/Login").tap do |url|
       url.query = URI.encode_www_form(
         target: target,

--- a/app/models/ht_approval_request.rb
+++ b/app/models/ht_approval_request.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class HTApprovalRequest < ApplicationRecord
+  self.primary_key = 'id'
   scope :not_renewed, -> { where(renewed: nil) }
   scope :for_approver, ->(approver) { where(approver: approver).order(:sent, :received, :renewed) }
   scope :not_renewed_for_approver, ->(approver) { where(approver: approver, renewed: nil).order(:sent, :received, :renewed) }


### PR DESCRIPTION
We need to come back from shib and hit /login so that the session gets
properly populated.