### PR TITLE
HT-1585: fixes for one-time links

### DIFF
--- a/app/controllers/approval_controller.rb
+++ b/app/controllers/approval_controller.rb
@@ -12,7 +12,7 @@ class ApprovalController < ApplicationController
     @token = params[:token]
     @req = HTApprovalRequest.find_by_token(params[:token])
 
-    return render_not_found unless @req&.crypt
+    return render_not_found unless @req&.token_hash
 
     @user = HTUser.where(email: @req.userid).first
     # detect duplicate uses of the link beforehand so shared/approval does

--- a/app/controllers/ht_approval_requests_controller.rb
+++ b/app/controllers/ht_approval_requests_controller.rb
@@ -32,6 +32,10 @@ class HTApprovalRequestsController < ApplicationController
     @reqs.group_by(&:renewal_state).map { |k, v| [k, v.length] }.to_h
   end
 
+  def edit
+    @preview = true
+  end
+
   private
 
   def fetch_requests

--- a/app/controllers/ht_approval_requests_controller.rb
+++ b/app/controllers/ht_approval_requests_controller.rb
@@ -14,7 +14,7 @@ class HTApprovalRequestsController < ApplicationController
 
   def update # rubocop:disable Metrics/MethodLength
     begin
-      ApprovalRequestMailer.with(reqs: @reqs).approval_request_email.deliver_now
+      ApprovalRequestMailer.with(reqs: @reqs, base_url: request.base_url).approval_request_email.deliver_now
       @reqs.each do |req|
         next unless req.mailable?
 

--- a/app/mailers/approval_request_mailer.rb
+++ b/app/mailers/approval_request_mailer.rb
@@ -7,6 +7,7 @@ class ApprovalRequestMailer < ApplicationMailer
 
   def approval_request_email
     @reqs = params[:reqs]
+    @base_url = params[:base_url]
     raise StandardError, 'Cannot send an email without at least one approval request' unless @reqs.count.positive?
 
     approvers = @reqs.pluck(:approver).uniq

--- a/app/models/ht_approval_request.rb
+++ b/app/models/ht_approval_request.rb
@@ -30,7 +30,7 @@ class HTApprovalRequest < ApplicationRecord
   # This is the bit that goes to the approver, just a gob of b64 data acting as a 'password'
   def token
     @token ||= decrypt(self[:crypt]) if self[:crypt]
-    @token ||= SecureRandom.base64 16
+    @token ||= SecureRandom.urlsafe_base64 16
   end
 
   # Does the approver alleging to have a valid token match this one?

--- a/app/models/ht_approval_request.rb
+++ b/app/models/ht_approval_request.rb
@@ -43,7 +43,7 @@ class HTApprovalRequest < ApplicationRecord
 
   def sent=(value)
     self[:sent] = value
-    self[:token_hash] = self.class.digest(token) unless self[:token_hash].present?
+    self[:token_hash] = self.class.digest(token)
   end
 
   def received(short: false)

--- a/app/models/ht_approval_request.rb
+++ b/app/models/ht_approval_request.rb
@@ -13,8 +13,8 @@ class HTApprovalRequest < ApplicationRecord
     constraint: -> { not_renewed },
     message: ->(_object, data) { "#{data[:value]} already has an approval request" }
   }
-  validates :crypt, presence: true, if: :sent
-  validates :sent, presence: true, if: :crypt
+  validates :token_hash, presence: true, if: :sent
+  validates :sent, presence: true, if: :token_hash
   validate :sent_before_received
 
   def sent_before_received
@@ -23,19 +23,17 @@ class HTApprovalRequest < ApplicationRecord
     errors.add(:sent, 'date sent cannot be after date received')
   end
 
+  def self.digest(tok)
+    Digest::SHA256.base64digest(Base64.decode64(tok))
+  end
+
   def self.find_by_token(tok)
-    HTApprovalRequest.find { |req| req if req.equals_token?(tok) }
+    HTApprovalRequest.find_by_token_hash(digest(tok))
   end
 
   # This is the bit that goes to the approver, just a gob of b64 data acting as a 'password'
   def token
-    @token ||= decrypt(self[:crypt]) if self[:crypt]
     @token ||= SecureRandom.urlsafe_base64 16
-  end
-
-  # Does the approver alleging to have a valid token match this one?
-  def equals_token?(token)
-    decrypt(self[:crypt]) == token.to_s
   end
 
   # Display datetime without UTC suffix or just date
@@ -45,7 +43,7 @@ class HTApprovalRequest < ApplicationRecord
 
   def sent=(value)
     self[:sent] = value
-    self[:crypt] = encrypt(token) unless self[:crypt].present?
+    self[:token_hash] = self.class.digest(token) unless self[:token_hash].present?
   end
 
   def received(short: false)
@@ -83,27 +81,6 @@ class HTApprovalRequest < ApplicationRecord
   end
 
   private
-
-  # https://dev.to/shobhitic/simple-string-encryption-in-rails-36pi
-  def encrypt(text)
-    text = text.to_s unless text.is_a? String
-    len = ActiveSupport::MessageEncryptor.key_len
-    salt = SecureRandom.hex len
-    key = ActiveSupport::KeyGenerator.new(Rails.application.secret_key_base).generate_key salt, len
-    crypt = ActiveSupport::MessageEncryptor.new key
-    encrypted_data = crypt.encrypt_and_sign text
-    "#{salt}$$#{encrypted_data}"
-  end
-
-  def decrypt(text)
-    return unless text
-
-    salt, data = text.split '$$'
-    len = ActiveSupport::MessageEncryptor.key_len
-    key = ActiveSupport::KeyGenerator.new(Rails.application.secret_key_base).generate_key salt, len
-    crypt = ActiveSupport::MessageEncryptor.new key
-    crypt.decrypt_and_verify data
-  end
 
   def date_field(field, short: false)
     if short

--- a/app/views/approval_request_mailer/approval_request_email.text.erb
+++ b/app/views/approval_request_mailer/approval_request_email.text.erb
@@ -30,7 +30,7 @@ Name  E-mail  Activity  Term  Expires
     <% unless role_stars[u.role] %>
       <% role_stars[u.role] = role_stars.count + 1 %>
     <% end %>
-<%= u.displayname %>  <%= u.email %>  <%= u.role %><%= '*' * role_stars[u.role] %>  <%= u.expiration_date.extension_period_text %>  <%= u.expires_string %>  <%= approve_url(req.token) %>
+<%= u.displayname %>  <%= u.email %>  <%= u.role %><%= '*' * role_stars[u.role] %>  <%= u.expiration_date.extension_period_text %>  <%= u.expires_string %>  <%= approve_url(req.token, host: @base_url) %>
   <% end %>
 
 <% role_stars.each do |k,v| %>

--- a/app/views/shared/_approval_request_email.html.erb
+++ b/app/views/shared/_approval_request_email.html.erb
@@ -44,7 +44,11 @@ or change staff with elevated access, please email
     <td style="padding: 6px;"><%= u.expiration_date.extension_period_text %></td>
     <td style="padding: 6px;"><%= u.expires_string %></td>
     <td style="padding: 6px;">
-      <%= link_to 'Approve User', approve_url(req.token), style: "font-weight: bold;" %>
+      <% if(@preview) %>
+        <b>Approve User</b>
+      <% else %>
+        <%= link_to 'Approve User', approve_url(req.token), style: "font-weight: bold;" %>
+      <% end %>
     </td>
   </tr>
   <% end %>

--- a/app/views/shared/_approval_request_email.html.erb
+++ b/app/views/shared/_approval_request_email.html.erb
@@ -47,7 +47,7 @@ or change staff with elevated access, please email
       <% if(@preview) %>
         <b>Approve User</b>
       <% else %>
-        <%= link_to 'Approve User', approve_url(req.token), style: "font-weight: bold;" %>
+        <%= link_to 'Approve User', approve_url(req.token, host: @base_url), style: "font-weight: bold;" %>
       <% end %>
     </td>
   </tr>

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,6 @@ module Otis
 
     config.relative_url_root = Otis.config.relative_url_root
 
-    config.action_mailer.default_url_options = { host: 'hathitrust.org' }
     config.action_mailer.smtp_settings = { address: Otis.config.smtp_host }
 
     # Settings in config/environments/* take precedence over those specified here.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,8 +35,6 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.default_url_options = { :host => "localhost:3000" }
-
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -33,8 +33,6 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.default_url_options = { :host => "localhost:3000" }
-
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -69,6 +69,6 @@ ActiveRecord::Schema.define(version: 0) do # rubocop:disable Metrics/BlockLength
     t.timestamp :sent
     t.timestamp :received
     t.timestamp :renewed
-    t.text :crypt
+    t.text :token_hash
   end
 end

--- a/test/controllers/ht_approval_requests_controller_test.rb
+++ b/test/controllers/ht_approval_requests_controller_test.rb
@@ -70,6 +70,12 @@ class HTApprovalRequestControllerShowTest < ActionDispatch::IntegrationTest
     assert_equal 'edit', @controller.action_name
   end
 
+  test 'edit page should not contain approval link' do
+    sign_in!
+    get edit_ht_approval_request_url @user1.approver
+    assert_no_match %r{/approve/}, response.body
+  end
+
   test 'should submit mail' do
     sign_in!
     patch ht_approval_request_url @user1.approver

--- a/test/controllers/ht_approval_requests_controller_test.rb
+++ b/test/controllers/ht_approval_requests_controller_test.rb
@@ -77,7 +77,7 @@ class HTApprovalRequestControllerShowTest < ActionDispatch::IntegrationTest
     assert_equal 'update', @controller.action_name
     follow_redirect!
     assert_not_nil @req.reload.sent
-    assert_not_nil @req.reload[:crypt]
+    assert_not_nil @req.reload[:token_hash]
     assert_equal 'show', @controller.action_name
   end
 

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -50,5 +50,10 @@ FactoryBot.define do
   factory :ht_approval_request do
     approver { Faker::Internet.email }
     userid { Faker::Internet.email }
+
+    trait :expired do
+      sent { Time.now - 7.days }
+      token_hash { Base64.encode64(Faker::String.random(32)) }
+    end
   end
 end

--- a/test/mailers/approval_request_mailer_test.rb
+++ b/test/mailers/approval_request_mailer_test.rb
@@ -12,6 +12,14 @@ class ApprovalRequestMailerTest < ActionMailer::TestCase
     @req3 = create(:ht_approval_request, userid: @user3.email, approver: @user3.approver)
   end
 
+  test 'link in email contains token' do
+    email = ApprovalRequestMailer.with(reqs: [@req1]).approval_request_email
+
+    email.parts.each do |p|
+      assert_match %r{/approve/#{@req1.token}}, p.to_s
+    end
+  end
+
   test 'send email for two users' do
     email = ApprovalRequestMailer.with(reqs: [@req1, @req2]).approval_request_email
 

--- a/test/models/ht_approval_request_test.rb
+++ b/test/models/ht_approval_request_test.rb
@@ -27,6 +27,24 @@ class HTApprovalRequestTest < ActiveSupport::TestCase
   test 'an old request is expired after a week' do
     assert build(:ht_approval_request, sent: (Time.now - 2.week)).expired?
   end
+
+  test 'hashed token matches token after setting sent' do
+    req = build(:ht_approval_request)
+
+    token = req.token
+    req.sent = Time.now
+
+    assert_equal(HTApprovalRequest.digest(token), req.token_hash)
+  end
+
+  test 'resending expired request resets hash' do
+    req = build(:ht_approval_request, :expired)
+
+    token = req.token
+    req.sent = Time.now
+
+    assert_equal(HTApprovalRequest.digest(token), req.token_hash)
+  end
 end
 
 class HTApprovalRequestUniquenessTest < ActiveSupport::TestCase


### PR DESCRIPTION
See notes on individual commits.

I've verified on useradmin-testing that I can:

- generate an approval request
- send the email
- receive the email
- use the link in the email when logged in as a non-privileged user (after changing the url to development)