### PR TITLE
HT-2115 and HT-1940 renewal for multiple users.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,17 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  # As a substitute for end-to-end logging, if there is no request in for
+  # the user's designated approver, we create one with the approver set to
+  # the HathiTrust staff member.
+  def add_or_update_renewal(email)
+    u = HTUser.where(email: email).first
+    raise StandardError, "Unknown user '#{email}'" if u.nil?
+
+    req = HTApprovalRequest.not_renewed_for_user(u.email).first
+    req = HTApprovalRequest.new(approver: current_user.id, userid: u.email) if req.nil?
+    req.renewed = Time.zone.now
+    req.save!
+    u.renew!
+  end
 end

--- a/app/models/ht_user.rb
+++ b/app/models/ht_user.rb
@@ -157,7 +157,7 @@ class HTUser < ApplicationRecord # rubocop:disable Metrics/ClassLength
     self.class.role_map[self[:role]]
   end
 
-  def renew
+  def renew!
     extend_by_default_period!
     save!
   end

--- a/app/presenters/ht_user_presenter.rb
+++ b/app/presenters/ht_user_presenter.rb
@@ -9,9 +9,13 @@ class HTUserPresenter < SimpleDelegator
     HTApprovalRequestPresenter.badge_for(approval_request)
   end
 
+  def renewed?
+    approval_request&.renewed.present?
+  end
+
   private
 
   def approval_request
-    @approval_request ||= HTApprovalRequest.not_renewed_for_user(email).first
+    @approval_request ||= HTApprovalRequest.for_user(email).first
   end
 end

--- a/app/views/ht_approval_requests/index.html.erb
+++ b/app/views/ht_approval_requests/index.html.erb
@@ -3,21 +3,29 @@
 
   <%= render 'shared/flash_message' %>
 
+  <%= form_tag(ht_approval_requests_path, method: :post) do %>
   <table id="active_users" class="table table-striped" data-toggle="table" data-height="460" data-virtual-scroll="true"
          data-search="true" data-show-search-clear-button="true">
     <thead class="thead-dark">
     <tr>
+      <th data-sortable="false">Select</th>
       <th data-sortable="true">Approver</th>
       <th data-sortable="true">User</th>
       <th data-sortable="true">Sent</th>
       <th data-sortable="true">Received</th>
+      <th data-sortable="true">Renewed</th>
     </tr>
     </thead>
 
     <% @reqs.each do |req| %>
-      <tr <%= raw @added_users&.include?(req.userid) ? 'class="success"' : '' %>>
+      <tr <%= raw @added_users.include?(req.userid) || @renewed_users.include?(req.userid) ? 'class="success"' : '' %>>
         <td>
-          <% if HTApprovalRequest.not_renewed_for_approver(req.approver).count.positive? %>
+          <% unless req.renewed.present? %>
+              <%= check_box_tag 'ht_users[]', req.userid %>
+            <% end %>
+          </td>
+        <td>
+          <% if HTApprovalRequest.for_approver(req.approver).count.positive? %>
             <%= link_to req.approver, ht_approval_request_path(req.approver) %>
           <% else %>
             <%= req.approver %>
@@ -31,8 +39,12 @@
           <% end %>
         </td>
         <td><%= req.received(short: true) %></td>
+        <td><%= req.renewed(short: true) %></td>
       </tr>
     <% end %>
   </table>
+  <br/>
+  <%= submit_tag 'Renew Selected Users', name: 'submit_renewals', class: 'btn btn-primary' %>
+  <% end # form-tag %>
 </div>
 

--- a/app/views/ht_users/edit.html.erb
+++ b/app/views/ht_users/edit.html.erb
@@ -57,8 +57,10 @@
         <dt><%= form.label :expires, expired_text %></dt>
         <dd><%= form.text_field :expires, value: @user.expires_string, size: 12, id: :expires_field, class: expires_class %>
           <% unless @user.expired? %>
-            <%= form.button "Expire Now", type: :button, onclick: "$('#expires_field').val('#{Time.current.to_s(:db)}');" %>
+            <%= form.button "Expire Now", type: :button, onclick: "$('#expires_field').val('#{Time.current.to_s(:db)}');", class: 'btn btn-primary' %>
           <% end %>
+          <% new_expiration = @user.expiration_date.default_extension_date %>
+          <%= form.button "Renew Now", type: :button, onclick: "$('#expires_field').val('#{new_expiration}');", class: 'btn btn-primary' %>
         </dd>
         <dt>Renewal Status</dt>
         <dd><%= @user.badge %></dd>
@@ -83,14 +85,8 @@
         <dd><%= @user.ht_count&.last_access&.to_s(:db) %></dd>
       </dl>
     </div>
-
-
-    <div>
-      <%= form.submit 'Submit Changes' %>
-    </div>
-
+    <%= form.submit 'Submit Changes', class: 'btn btn-primary' %>
+    <%= link_to 'Cancel', ht_user_path(@user), class: 'btn btn-primary' %>
   <% end %>
-
-  <%= link_to 'Back', ht_users_path %>
 </div>
 

--- a/app/views/ht_users/index.html.erb
+++ b/app/views/ht_users/index.html.erb
@@ -2,14 +2,10 @@
   <h1>Users</h1>
 
   <%= render 'shared/flash_message' %>
-  <%= form_tag(ht_users_path, method: :get) do %>
-    E-mail <%= text_field_tag :email, params[:email] %>
-    <%= submit_tag 'Search', name: nil %>
-  <% end %>
 
   <%= form_tag(ht_approval_requests_path, method: :post) do %>
 
-  <h2>Active Users</h2>
+  <h2 class="pull-left">Active Users</h2>
   <table id="active_users" class="table table-striped" data-toggle="table" data-height="460" data-virtual-scroll="true"
          data-search="true" data-show-search-clear-button="true">
     <thead class="thead-dark">
@@ -29,7 +25,7 @@
     <% @users.each do |u| %>
       <tr>
         <td>
-          <% unless u.approval_requested? %>
+          <% unless u.renewed? %>
             <%= check_box_tag 'ht_users[]', u.email %>
           <% end %>
         </td>
@@ -55,10 +51,11 @@
     <% end %>
   </table>
   <br/>
-  <%= submit_tag 'Generate Approval Requests', name: 'submit_req', class: 'btn btn-primary' %>
+  <%= submit_tag 'Create Approval Requests', name: 'submit_requests', class: 'btn btn-primary' %>
+  <%= submit_tag 'Renew Selected Users', name: 'submit_renewals', class: 'btn btn-primary' %>
   <% end # form-with %>
 
-  <h2>Expired Users</h2>
+  <h2 class="pull-left">Expired Users</h2>
   <table id="expired_users" class="table table-striped" data-toggle="table" data-height="460" data-virtual-scroll="true"
          data-search="true" data-thead-classes="thead-dark" data-show-search-clear-button="true">
     <thead>

--- a/test/controllers/approval_controller_test.rb
+++ b/test/controllers/approval_controller_test.rb
@@ -16,7 +16,7 @@ class ApprovalControllerTest < ActionDispatch::IntegrationTest
     assert_match @req.userid, @response.body
     assert_match @req.approver, @response.body
     assert_not_nil @req.reload.received
-    assert_equal Date.parse(@req.reload.received).to_s, Date.today.to_s
+    assert_equal Date.parse(@req.reload.received).to_s, Date.parse(Time.zone.now.to_s).to_s
   end
 
   test 'refuses to approve the same request a second time' do

--- a/test/models/ht_user_test.rb
+++ b/test/models/ht_user_test.rb
@@ -159,28 +159,28 @@ class HTUserRenewal < ActiveSupport::TestCase
   end
 
   test 'User expiresannually' do
-    @expiresannually_user.renew
+    @expiresannually_user.renew!
     assert_in_delta(365, @expiresannually_user.days_until_expiration, 1)
   end
 
   test 'User expiresbiannually' do
-    @expiresbiannually_user.renew
+    @expiresbiannually_user.renew!
     assert_in_delta(730, @expiresbiannually_user.days_until_expiration, 1)
   end
 
   test 'User expirescustom90' do
-    @expirescustom90_user.renew
+    @expirescustom90_user.renew!
     assert_in_delta(90, @expirescustom90_user.days_until_expiration, 5)
   end
 
   test 'User expirescustom60' do
-    @expirescustom60_user.renew
+    @expirescustom60_user.renew!
     assert_in_delta(60, @expirescustom60_user.days_until_expiration, 3)
   end
 
   test 'User with unknown expire_type' do
     assert_raise StandardError do
-      @unknown_user.renew
+      @unknown_user.renew!
     end
   end
 end


### PR DESCRIPTION
As demonstrated to HT staff 2020-05-21.
Issue with excessively sticky flash message fixed.
Issue with existing approval request not being updated from approver -> HT staff not addressed because we don't know the extent of out-of-band communication with the approver, so for now let's leave the approver's identity intact on the request, even if (in the unlikely event) the request e-mail was never sent.