### PR TITLE
Ht 2351 approval user email

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,7 +20,7 @@ Layout/SpaceInsideHashLiteralBraces:
 Metrics/AbcSize:
   Enabled: false
 
-Layouts/LineLength:
+Layout/LineLength:
   Enabled: false
 
 Metrics/ClassLength:

--- a/app/controllers/ht_approval_requests_controller.rb
+++ b/app/controllers/ht_approval_requests_controller.rb
@@ -31,10 +31,11 @@ class HTApprovalRequestsController < ApplicationController
       @reqs.each do |req|
         next unless req.mailable?
 
+        UserMailer.with(req: req, base_url: request.base_url).approval_request_user_email.deliver_now
         req.sent = Time.now
         req.save!
       end
-      flash[:notice] = 'Message sent'
+      flash[:notice] = 'Messages sent'
     rescue StandardError => e
       flash[:alert] = e.message
     end

--- a/app/controllers/ht_approval_requests_controller.rb
+++ b/app/controllers/ht_approval_requests_controller.rb
@@ -31,7 +31,7 @@ class HTApprovalRequestsController < ApplicationController
       @reqs.each do |req|
         next unless req.mailable?
 
-        UserMailer.with(req: req, base_url: request.base_url).approval_request_user_email.deliver_now
+        UserMailer.with(req: req).approval_request_user_email.deliver_now
         req.sent = Time.now
         req.save!
       end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class UserMailer < ApplicationMailer
+  def approval_request_user_email
+    @req = params[:req]
+    @base_url = params[:base_url]
+    raise StandardError, 'Cannot send email without an approval request' unless @req.present?
+
+    @user = HTUser.find(@req.userid)
+    mail(to: @req.userid, subject: 'HathiTrust Elevated Access Status')
+  end
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -3,7 +3,6 @@
 class UserMailer < ApplicationMailer
   def approval_request_user_email
     @req = params[:req]
-    @base_url = params[:base_url]
     raise StandardError, 'Cannot send email without an approval request' unless @req.present?
 
     @user = HTUser.find(@req.userid)

--- a/app/views/shared/_approval_request_user_email.html.erb
+++ b/app/views/shared/_approval_request_user_email.html.erb
@@ -1,0 +1,7 @@
+<p>Hello</p>
+<p>Your special access to in-copyright volumes in HathiTrust is scheduled to
+expire on <%= @user.expires_string %>. Renewal instructions have been sent to your
+approver at <%= @user.approver %>.</p>
+<p>Please contact us at <a href="mailto:feedback@issues.hathitrust.org">feedback@issues.hathitrust.org</a>
+if there are any issues with your renewal.</p>
+<p>Thank you,<br/>HathiTrust User Support<br/></p>

--- a/app/views/user_mailer/approval_request_user_email.html.erb
+++ b/app/views/user_mailer/approval_request_user_email.html.erb
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <%= render 'shared/approval_request_user_email' %>
+  </body>
+</html>

--- a/app/views/user_mailer/approval_request_user_email.text.erb
+++ b/app/views/user_mailer/approval_request_user_email.text.erb
@@ -1,0 +1,11 @@
+Hello,
+
+Your special access to in-copyright volumes in HathiTrust is scheduled to
+expire on <%= @user.expires_string %>. Renewal instructions have been sent to your
+approver at <%= @user.approver %>.
+
+Please contact us at feedback@issues.hathitrust.org
+if there are any issues with your renewal.
+
+Thank you,
+HathiTrust User Support

--- a/test/mailers/previews/approval_request_mailer_preview.rb
+++ b/test/mailers/previews/approval_request_mailer_preview.rb
@@ -7,6 +7,6 @@ class ApprovalRequestMailerPreview < ActionMailer::Preview
       reqs << req.dup
       reqs.last[:approver] = 'approver@example.com'
     end
-    ApprovalRequestMailer.with(reqs: reqs).approval_request_email
+    ApprovalRequestMailer.with(reqs: reqs, base_url: 'http://default.invalid').approval_request_email
   end
 end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -3,6 +3,6 @@
 class UserMailerPreview < ActionMailer::Preview
   def approval_request_companion_email
     req = HTApprovalRequest.all.sample(1).first
-    UserMailer.with(req: req, base_url: 'www.example.com').approval_request_user_email
+    UserMailer.with(req: req).approval_request_user_email
   end
 end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class UserMailerPreview < ActionMailer::Preview
+  def approval_request_companion_email
+    req = HTApprovalRequest.all.sample(1).first
+    UserMailer.with(req: req, base_url: 'www.example.com').approval_request_user_email
+  end
+end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class UserMailerTest < ActionMailer::TestCase
+  def setup
+    @base_url = 'http://default.invalid'
+    @user1 = create(:ht_user, email: 'user1@example.com', approver: 'approver@example.com')
+    @req1 = create(:ht_approval_request, userid: @user1.email, approver: @user1.approver)
+  end
+
+  test 'send email for one request' do
+    email = UserMailer
+            .with(req: @req1, base_url: @base_url)
+            .approval_request_user_email
+
+    assert_emails 1 do
+      email.deliver_now
+    end
+    assert_equal [ApplicationMailer.default[:from]], email.from
+    assert_equal ['user1@example.com'], email.to
+  end
+
+  test 'fail to send email for zero requests' do
+    assert_raise StandardError do
+      UserMailer
+        .with(req: nil, base_url: @base_url)
+        .approval_request_user_email
+        .deliver_now
+    end
+  end
+end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -4,14 +4,13 @@ require 'test_helper'
 
 class UserMailerTest < ActionMailer::TestCase
   def setup
-    @base_url = 'http://default.invalid'
     @user1 = create(:ht_user, email: 'user1@example.com', approver: 'approver@example.com')
     @req1 = create(:ht_approval_request, userid: @user1.email, approver: @user1.approver)
   end
 
   test 'send email for one request' do
     email = UserMailer
-            .with(req: @req1, base_url: @base_url)
+            .with(req: @req1)
             .approval_request_user_email
 
     assert_emails 1 do
@@ -24,7 +23,7 @@ class UserMailerTest < ActionMailer::TestCase
   test 'fail to send email for zero requests' do
     assert_raise StandardError do
       UserMailer
-        .with(req: nil, base_url: @base_url)
+        .with(req: nil)
         .approval_request_user_email
         .deliver_now
     end


### PR DESCRIPTION
Left open the option of previewing the HTML e-mail in the approval request edit page, but that would require instantiating HTUser in the view, or some other cleverness.

A couple of additional commits with routine fixes thrown in.