### PR TITLE
HT-1195: make email to approvers editable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,7 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'autoprefixer-rails'
 gem 'bootstrap-sass'
 gem 'jquery-rails'
+gem 'ckeditor'
 
 gem 'ettin'
 gem 'keycard'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,8 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    ckeditor (5.1.0)
+      orm_adapter (~> 0.5.0)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -126,6 +128,7 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
+    orm_adapter (0.5.0)
     parallel (1.19.1)
     parser (2.7.1.2)
       ast (~> 2.4.0)
@@ -250,6 +253,7 @@ DEPENDENCIES
   bootstrap-sass
   byebug
   capybara (>= 2.15, < 4.0)
+  ckeditor
   coffee-rails (~> 4.2)
   dotenv-rails
   ettin

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,5 +14,4 @@
 //= require bootstrap
 //= require rails-ujs
 //= require activestorage
-//= require turbolinks
 //= require_tree .

--- a/app/controllers/ht_approval_requests_controller.rb
+++ b/app/controllers/ht_approval_requests_controller.rb
@@ -27,7 +27,7 @@ class HTApprovalRequestsController < ApplicationController
 
   def update # rubocop:disable Metrics/MethodLength
     begin
-      ApprovalRequestMailer.with(reqs: @reqs, base_url: request.base_url).approval_request_email.deliver_now
+      ApprovalRequestMailer.with(reqs: @reqs, base_url: request.base_url, body: params[:email_body]).approval_request_email.deliver_now
       @reqs.each do |req|
         next unless req.mailable?
 
@@ -48,6 +48,7 @@ class HTApprovalRequestsController < ApplicationController
 
   def edit
     @preview = true
+    @email_body = render_to_string partial: 'shared/approval_request_body'
   end
 
   private

--- a/app/mailers/approval_request_mailer.rb
+++ b/app/mailers/approval_request_mailer.rb
@@ -8,6 +8,7 @@ class ApprovalRequestMailer < ApplicationMailer
   def approval_request_email
     @reqs = params[:reqs]
     @base_url = params[:base_url]
+    @body = params[:body]
     raise StandardError, 'Cannot send an email without at least one approval request' unless @reqs.count.positive?
 
     approvers = @reqs.pluck(:approver).uniq

--- a/app/views/approval_request_mailer/approval_request_email.html.erb
+++ b/app/views/approval_request_mailer/approval_request_email.html.erb
@@ -4,6 +4,9 @@
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
   </head>
   <body>
-    <%= render 'shared/approval_request_email' %>
+    <div>
+      <%= sanitize(@body) %>
+    </div>
+    <%= render 'shared/approval_request_user_table' %>
   </body>
 </html>

--- a/app/views/approval_request_mailer/approval_request_email.text.erb
+++ b/app/views/approval_request_mailer/approval_request_email.text.erb
@@ -1,27 +1,4 @@
-Hello,
-
-You are the institutional approver on file with HathiTrust for the
-following list of users who have special access to in-copyright
-volumes.
-
-Their access term is about to expire and they will lose special access
-unless you reauthorize them. Please review the following people and
-click the Approve User link for those whose access you
-reauthorize for another term.
-
-There are various reasons that people are approved for special access
-such as to manage the Accessible Text Request Service, perform copyright
-review, do development, or manage quality corrections.
-The table below includes the user name, the activity they were approved
-for, their access term, and the access expiration date among other
-information.
-
-If you are no longer supervising the staff listed below or if you need to add
-or change staff with elevated access, please email
-mailto:feedback@issues.hathitrust.org.
-
-Thank you,
-HathiTrust User Support
+<%= strip_tags @body %>
 
 Name  E-mail  Activity  Term  Expires
   <% role_stars = {} %>

--- a/app/views/ht_approval_requests/edit.html.erb
+++ b/app/views/ht_approval_requests/edit.html.erb
@@ -1,3 +1,5 @@
+<%= javascript_include_tag Ckeditor.cdn_url %>
+
 <div id="maincontent" class="row">
   <h1>Approval Requests for <%= params[:id] %></h1>
 
@@ -14,15 +16,18 @@
     <% end %>
     </ul>
     <!-- MAIL PREVIEW -->
-    <div class="panel panel-default">
-      <div class="panel-heading">E-mail Preview</div>
-      <div class="panel-body">
-        <%= render 'shared/approval_request_email' %>
-      </div>
-    </div>
     <% counts = controller.status_counts %>
     <% if counts[:unsent]&.positive? || counts[:expired]&.positive? %>
       <%= form_tag ht_approval_request_path, method: :put do %>
+        <div class="panel panel-default">
+          <div class="panel-heading">E-mail Preview</div>
+          <div class="panel-body">
+            <%= cktext_area_tag :email_body, @email_body, ckeditor: { height: '325px' } %>
+          </div>
+          <div class="panel-body">
+            <%= render 'shared/approval_request_user_table' %>
+          </div>
+        </div>
         <% label = counts[:expired]&.positive? ? 'RESEND' : 'SEND' %>
         <%= submit_tag label, class: 'btn btn-primary' %>
         <%= link_to 'Cancel', ht_approval_request_path(@reqs[0].approver), class: 'btn btn-primary' %>

--- a/app/views/ht_approval_requests/show.html.erb
+++ b/app/views/ht_approval_requests/show.html.erb
@@ -13,6 +13,9 @@
       </li>
     <% end %>
     </ul>
-    <%= link_to 'Edit', edit_ht_approval_request_path, class: 'btn btn-primary' %>
+    <% counts = controller.status_counts %>
+    <% if counts[:unsent]&.positive? || counts[:expired]&.positive? %>
+      <%= link_to 'Edit', edit_ht_approval_request_path, class: 'btn btn-primary' %>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/shared/_approval_request_body.html.erb
+++ b/app/views/shared/_approval_request_body.html.erb
@@ -1,0 +1,22 @@
+<p>Hello</p>
+<p>You are the institutional approver on file with HathiTrust for the
+following list of users who have special access to in-copyright
+volumes.<br/></p>
+
+<p>Their access term is about to expire and they will lose special access
+unless you reauthorize them. Please review the following people and
+click the <strong>Approve User</strong> link for those whose access you
+reauthorize for another term.<br/></p>
+
+<p>There are various reasons that people are approved for special access
+such as to manage the Accessible Text Request Service, perform copyright
+review, do development, or manage quality corrections.
+The table below includes the user name, the activity they were approved
+for, their access term, and the access expiration date among other
+information.<br/></p>
+
+<p>If you are no longer supervising the staff listed below or if you need to add
+or change staff with elevated access, please email
+<a href="mailto:feedback@issues.hathitrust.org">feedback@issues.hathitrust.org</a>.
+
+<p>Thank you,<br/>HathiTrust User Support<br/></p>

--- a/app/views/shared/_approval_request_user_table.html.erb
+++ b/app/views/shared/_approval_request_user_table.html.erb
@@ -1,26 +1,3 @@
-<p>Hello</p>
-<p>You are the institutional approver on file with HathiTrust for the
-following list of users who have special access to in-copyright
-volumes.<br/></p>
-
-<p>Their access term is about to expire and they will lose special access
-unless you reauthorize them. Please review the following people and
-click the <strong>Approve User</strong> link for those whose access you
-reauthorize for another term.<br/></p>
-
-<p>There are various reasons that people are approved for special access
-such as to manage the Accessible Text Request Service, perform copyright
-review, do development, or manage quality corrections.
-The table below includes the user name, the activity they were approved
-for, their access term, and the access expiration date among other
-information.<br/></p>
-
-<p>If you are no longer supervising the staff listed below or if you need to add
-or change staff with elevated access, please email
-<a href="mailto:feedback@issues.hathitrust.org">feedback@issues.hathitrust.org</a>.
-
-<p>Thank you,<br/>HathiTrust User Support<br/></p>
-
 <table style="border: 1px solid black; border-collapse: collapse;">
 <tr style="border: 1px solid black;">
   <th style="padding: 6px; text-align: left;">Name</th>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,3 +12,4 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
+Rails.application.config.assets.precompile += %w[ckeditor/config.js]

--- a/config/initializers/ckeditor.rb
+++ b/config/initializers/ckeditor.rb
@@ -1,0 +1,4 @@
+Ckeditor.setup do |config|
+  # //cdn.ckeditor.com/<version.number>/<distribution>/ckeditor.js
+  config.cdn_url = "//cdn.ckeditor.com/4.6.1/basic/ckeditor.js"
+end


### PR DESCRIPTION
- Adds ckeditor for HTML editing
- Does not (yet) persist the email anywhere after it's sent
- Disable turbolinks, since it messes with ckeditor