### PR TITLE
HT-2397: simplify shib config

### DIFF
--- a/app/controllers/session_controller.rb
+++ b/app/controllers/session_controller.rb
@@ -41,10 +41,9 @@ class SessionController < ApplicationController
   end
 
   def shib_login_url(target = request.original_url)
-    URI("#{Otis.config.shibboleth.sp.url}/Login").tap do |url|
+    URI(Otis.config.shibboleth.url).tap do |url|
       url.query = URI.encode_www_form(
-        target: target,
-        entityID: Otis.config.shibboleth.default_idp.entity_id
+        target: target
       )
     end.to_s
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,13 +7,4 @@ users: []
 # How many days away does expiration need to be before we start to worry?
 expires_soon_in_days: 30
 
-
-shibboleth:
-  fallback_to_idp: true
-  default_idp:
-    entity_id: https://shibboleth.umich.edu/idp/shibboleth
-  sp:
-    url: /Shibboleth.sso
-    entity_id: https://hathitrust.org/sp
-
 manager_email: manager@default.invalid

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -10,11 +10,6 @@ users:
   - somebody@default.invalid
 
 shibboleth:
-  fallback_to_idp: true
-  default_idp:
-    entity_id: https://shibboleth.umich.edu/idp/shibboleth
-  sp:
-    url: /useradmin/Shibboleth.sso
-    entity_id: https://hathitrust.org/sp
+  url: /useradmin/Shibboleth.sso/Login
 
 smtp_host: localhost

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -10,3 +10,6 @@ keycard:
   database:
     adapter: sqlite
     database: tmp/keycard_test.sqlite3
+
+shibboleth:
+  url: /useradmin/Shibboleth.sso/Login


### PR DESCRIPTION
This allows us to specify a URL for the WAYF to send users through
rather than defaulting to a specific IdP, which is necessary for the
one-time use links and not a problem for manager user.