### PR TITLE
HTS-139075: accept user_pid attribute for authentication

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -72,7 +72,8 @@ class ApplicationController < ActionController::Base
       methods: [
         Keycard::Authentication::AuthToken.bind_class_method(:User, :authenticate_by_auth_token),
         Keycard::Authentication::SessionUserId.bind_class_method(:User, :authenticate_by_id),
-        Keycard::Authentication::UserEid.bind_class_method(:User, :authenticate_by_user_eid)
+        Keycard::Authentication::UserEid.bind_class_method(:User, :authenticate_by_user_eid),
+        Otis::Authentication::UserPid.bind_class_method(:User, :authenticate_by_user_pid)
       ]
     )
   end

--- a/app/lib/otis/authentication/user_pid.rb
+++ b/app/lib/otis/authentication/user_pid.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Otis
+  module Authentication
+    class UserPid < Keycard::Authentication::Method
+      def apply
+        if user_pid.nil?
+          skipped('No user_pid found in request attributes')
+        elsif (account = finder.call(user_pid))
+          succeeded(account, "Account found for user_pid '#{user_pid}'")
+        else
+          failed("Account not found for user_pid '#{user_pid}'")
+        end
+      end
+
+      private
+
+      def user_pid
+        attributes.user_pid
+      end
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,10 @@ class User
     User.new(eid)
   end
 
+  def self.authenticate_by_user_pid(pid)
+    User.new(pid)
+  end
+
   def initialize(eid)
     @id = eid
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -21,6 +21,12 @@ class UserTest < ActiveSupport::TestCase
     assert_equal user.id, 'eid'
   end
 
+  test 'authenticate_by_user_pid returns a User' do
+    user = User.authenticate_by_user_pid('pid')
+    assert_instance_of User, user
+    assert_equal user.id, 'pid'
+  end
+
   test 'new returns a User' do
     user = User.new('id')
     assert_instance_of User, user


### PR DESCRIPTION
This fixes an issue where users' authentication is rejected whose
identity provider do not send eduPersonPrincipalName or another
attribute that can be mapped to user_eid.

Otis::Authentication::UserPid is a straight copy-paste of
Keycard::Authentication::UserEid and included here without tests. It
should be tested when it is integrated into Keycard.

I will test this with useradmin-testing by removing Apache sending eduPersonPrincipalName, mail, etc headers and ensuring that authentication still succeeds.
