### PR TITLE
HT-2408: Add ability to remove IP restriction

### DIFF
--- a/app/models/ip_restriction.rb
+++ b/app/models/ip_restriction.rb
@@ -25,7 +25,11 @@ class IPRestriction
   end
 
   def self.from_string(addrs)
-    new(addrs.split(/\s*,\s*/).map(&:strip))
+    if addrs == 'any'
+      any
+    else
+      new(addrs.split(/\s*,\s*/).map(&:strip))
+    end
   end
 
   def self.from_regex(regex)
@@ -52,4 +56,10 @@ class IPRestriction::Any
   def to_regex
     '^.*$'
   end
+
+  def addrs
+    ['any']
+  end
+
+  def validate; end
 end

--- a/app/models/ip_restriction.rb
+++ b/app/models/ip_restriction.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+class IPRestriction
+  attr_reader :addrs
+
+  def initialize(addrs = [])
+    @addrs = addrs
+  end
+
+  def validate
+    addrs.each do |addr|
+      parsed = IPAddr.new(addr)
+      raise ArgumentError, "#{addr} is an IPv6 address; only IPv4 addresses allowed" if parsed.ipv6?
+      raise ArgumentError, "#{addr} is a private IPv4 address; only public addresses allowed" if parsed.private?
+      raise ArgumentError, "#{addr} is a loopback IPv4 address; only public addresses allowed" if parsed.loopback?
+    end
+  end
+
+  def self.any
+    IPRestriction::Any.new
+  end
+
+  def self.unescape(regex)
+    regex.gsub(/^\^/, '').gsub(/\$$/, '').gsub(/\\\./, '.')
+  end
+
+  def self.from_string(addrs)
+    new(addrs.split(/\s*,\s*/).map(&:strip))
+  end
+
+  def self.from_regex(regex)
+    case regex
+    when nil
+      nil
+    when '^.*$'
+      any
+    else
+      new(regex.split('|').map { |escaped| unescape(escaped) })
+    end
+  end
+
+  def to_regex
+    return unless addrs.any?
+
+    addrs.map do |addr|
+      '^' + Regexp.escape(addr) + '$'
+    end.join('|')
+  end
+end
+
+class IPRestriction::Any
+  def to_regex
+    '^.*$'
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,10 +33,12 @@ def create_ht_user(expires:)
   else
     u.identity_provider = HTInstitution.enabled.sample.entityID
     # Faker::Boolean.boolean(true_ratio: 0.2) fails with "ArgumentError (comparison of Float with Hash failed)"
-    if rand > 0.2
-      u.iprestrict = Faker::Internet.ip_v4_address
+    if rand > 0.4
+      u.iprestrict = Faker::Internet.public_ip_v4_address
+    elsif rand > 0.2
+      u.iprestrict = 'any'
     else
-      u.iprestrict = "#{Faker::Internet.ip_v4_address}, #{Faker::Internet.ip_v4_address}"
+      u.iprestrict = "#{Faker::Internet.public_ip_v4_address}, #{Faker::Internet.public_ip_v4_address}"
     end
   end
   u.save!

--- a/test/controllers/ht_users_controller_test.rb
+++ b/test/controllers/ht_users_controller_test.rb
@@ -59,13 +59,13 @@ class HTUsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'edit IP address fails' do
-    user = create(:ht_user, iprestrict: '127.0.0.2')
+    user = create(:ht_user, iprestrict: '1.2.3.4')
     sign_in!
     patch ht_user_url user, params: {'ht_user' => {'iprestrict' => '33.33.33.blah'}}
     assert_response :success
     assert_equal 'update', @controller.action_name
-    assert_match 'IPv4', flash[:alert]
-    assert_match '127.0.0.2', @response.body
+    assert_match 'invalid address', flash[:alert]
+    assert_match '1.2.3.4', @response.body
   end
 
   test 'updating expiration for mfa user retains nil iprestrict' do

--- a/test/controllers/ht_users_controller_test.rb
+++ b/test/controllers/ht_users_controller_test.rb
@@ -68,6 +68,18 @@ class HTUsersControllerTest < ActionDispatch::IntegrationTest
     assert_match '1.2.3.4', @response.body
   end
 
+  test 'removing IP restriction succeeds' do
+    sign_in!
+    patch ht_user_url @user1, params: {'ht_user' => {'iprestrict' => 'any'}}
+    assert_response :redirect
+    assert_equal 'update', @controller.action_name
+    assert_not_empty flash[:notice]
+    assert_redirected_to ht_user_path(@user1.email)
+    follow_redirect!
+    assert_match 'any', @response.body
+    assert_equal '^.*$', HTUser.find(@user1.email)[:iprestrict]
+  end
+
   test 'updating expiration for mfa user retains nil iprestrict' do
     user = create(:ht_user_mfa)
     sign_in!

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     email { Faker::Internet.email }
     expire_type { ExpirationDate::EXPIRES_TYPE.keys.sample.to_s }
     expires { Faker::Time.forward }
-    iprestrict { Faker::Internet.ip_v4_address }
+    iprestrict { Faker::Internet.public_ip_v4_address }
     ht_institution
 
     trait :active

--- a/test/models/ht_user_test.rb
+++ b/test/models/ht_user_test.rb
@@ -12,19 +12,19 @@ class HTUserTest < ActiveSupport::TestCase
   end
 
   test 'iprestrict to English' do
-    assert_equal HTUser.human_attribute_name(:iprestrict), 'IP Restriction'
+    assert_equal 'IP Restriction', HTUser.human_attribute_name(:iprestrict)
   end
 
   test 'iprestrict escaping and unescaping' do
-    user = build(:ht_user, iprestrict: '127.0.0.1')
-    assert_equal user[:iprestrict], '^127\.0\.0\.1$'
-    assert_equal user.iprestrict, ['127.0.0.1']
+    user = build(:ht_user, iprestrict: '1.2.3.4')
+    assert_equal '^1\.2\.3\.4$', user[:iprestrict]
+    assert_equal ['1.2.3.4'], user.iprestrict
   end
 
   test 'iprestrict with whitespace' do
-    user = build(:ht_user, iprestrict: ' 127.0.0.1 ')
-    assert_equal user[:iprestrict], '^127\.0\.0\.1$'
-    assert_equal user.iprestrict, ['127.0.0.1']
+    user = build(:ht_user, iprestrict: ' 1.2.3.4 ')
+    assert_equal '^1\.2\.3\.4$', user[:iprestrict]
+    assert_equal ['1.2.3.4'], user.iprestrict
   end
 
   test 'expires validation rejects various bogative timestamps' do
@@ -103,7 +103,7 @@ class HTUserMFA < ActiveSupport::TestCase
   end
 
   test 'User with MFA and no iprestrict is valid' do
-    assert_equal(@mfa_user.mfa, true)
+    assert_equal true, @mfa_user.mfa
     assert_nil @mfa_user.iprestrict
     assert @mfa_user.valid?
   end
@@ -111,19 +111,19 @@ end
 
 class HTUserMultipleIprestrict < ActiveSupport::TestCase
   def setup
-    @multi_ip_user = build(:ht_user, mfa: false, iprestrict: '127.0.0.1, 127.0.0.2')
-    @bogus_multi_ip_user = build(:ht_user, mfa: false, iprestrict: '127.0.0.1, 127.0.0.2.0')
+    @multi_ip_user = build(:ht_user, mfa: false, iprestrict: '1.2.3.4, 5.6.7.8')
+    @bogus_multi_ip_user = build(:ht_user, mfa: false, iprestrict: '1.2.3.4, 1.2.3.4.5')
   end
 
   test 'User with multiple iprestrict is valid' do
-    assert_equal(@multi_ip_user.mfa, false)
+    assert_equal false, @multi_ip_user.mfa
     assert_instance_of Array, @multi_ip_user.iprestrict
     assert @multi_ip_user.valid?
   end
 
   test 'User with one of two IPs bogus is not valid' do
-    assert_equal @bogus_multi_ip_user [:iprestrict], '^127\.0\.0\.1$|^127\.0\.0\.2\.0$'
-    assert_equal @bogus_multi_ip_user.iprestrict, ['127.0.0.1', '127.0.0.2.0']
+    assert_equal '^1\.2\.3\.4$|^1\.2\.3\.4\.5$', @bogus_multi_ip_user [:iprestrict]
+    assert_equal ['1.2.3.4', '1.2.3.4.5'], @bogus_multi_ip_user.iprestrict
     assert_not @bogus_multi_ip_user.valid?
     assert_not_empty @bogus_multi_ip_user.errors.messages[:iprestrict]
   end

--- a/test/models/ip_restriction_test.rb
+++ b/test/models/ip_restriction_test.rb
@@ -52,6 +52,10 @@ class IPRestrictionFromStringTest < ActiveSupport::TestCase
   test 'can parse a string with whitespace' do
     assert_equal(['1.2.3.4'], IPRestriction.from_string(' 1.2.3.4 ').addrs)
   end
+
+  test 'can parse the any string' do
+    assert_instance_of(IPRestriction::Any, IPRestriction.from_string('any'))
+  end
 end
 
 class IPRestrictionFromRegexTest < ActiveSupport::TestCase
@@ -83,5 +87,9 @@ end
 class IPRestrictionAnyTest < ActiveSupport::TestCase
   test 'converts to a regex matching anything' do
     assert_equal('^.*$', IPRestriction.any.to_regex)
+  end
+
+  test 'converts to the any string' do
+    assert_equal(['any'], IPRestriction.any.addrs)
   end
 end

--- a/test/models/ip_restriction_test.rb
+++ b/test/models/ip_restriction_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class IPRestrictionTest < ActiveSupport::TestCase
+  test 'turns a single valid string-formatted IPv4 address into a regular expression' do
+    assert_equal('^1\.2\.3\.4$', IPRestriction.new(['1.2.3.4']).to_regex)
+  end
+
+  test 'turns multiple valid string-formatted IPv4 addresses into a regular expression' do
+    assert_equal('^1\.2\.3\.4$|^5\.6\.7\.8$', IPRestriction.new(['1.2.3.4', '5.6.7.8']).to_regex)
+  end
+
+  test 'returns nil when there are no addresses' do
+    assert_nil(IPRestriction.new.to_regex)
+  end
+
+  test 'rejects out-of-range IPs' do
+    assert_raises ArgumentError do
+      IPRestriction.new(['256.257.258.259']).validate
+    end
+  end
+
+  test 'rejects IPv6 IPs' do
+    assert_raises ArgumentError do
+      IPRestriction.new(['2001:1234::1']).validate
+    end
+  end
+
+  test 'rejects non-public IPs' do
+    assert_raises ArgumentError do
+      IPRestriction.new(['10.1.2.3']).validate
+    end
+  end
+
+  test 'rejects loopback IPs' do
+    assert_raises ArgumentError do
+      IPRestriction.new(['127.0.0.1']).validate
+    end
+  end
+end
+
+class IPRestrictionFromStringTest < ActiveSupport::TestCase
+  test 'can parse a string' do
+    assert_equal(['1.2.3.4'], IPRestriction.from_string('1.2.3.4').addrs)
+  end
+
+  test 'can parse a string with multiple IPs' do
+    assert_equal(['1.2.3.4', '5.6.7.8'], IPRestriction.from_string('1.2.3.4,5.6.7.8').addrs)
+  end
+
+  test 'can parse a string with whitespace' do
+    assert_equal(['1.2.3.4'], IPRestriction.from_string(' 1.2.3.4 ').addrs)
+  end
+end
+
+class IPRestrictionFromRegexTest < ActiveSupport::TestCase
+  test 'can parse a regex matching any IP' do
+    assert_instance_of(IPRestriction::Any, IPRestriction.from_regex('^.*$'))
+  end
+
+  test 'raises ArgumentError for unparseable nonsense' do
+    assert_raises ArgumentError do
+      IPRestriction.from_regex('this is not an IP address').validate
+    end
+  end
+
+  test 'returns nil with a nil regex' do
+    assert_nil(IPRestriction.from_regex(nil))
+  end
+
+  test 'can round-trip a single IP' do
+    regex = '^1\.2\.3\.4$'
+    assert_equal regex, IPRestriction.from_regex(regex).to_regex
+  end
+
+  test 'can round-trip multiple IPs' do
+    regex = '^1\.2\.3\.4$|^5\.6\.7\.8$'
+    assert_equal regex, IPRestriction.from_regex(regex).to_regex
+  end
+end
+
+class IPRestrictionAnyTest < ActiveSupport::TestCase
+  test 'converts to a regex matching anything' do
+    assert_equal('^.*$', IPRestriction.any.to_regex)
+  end
+end


### PR DESCRIPTION
This fixes an issue where users whose iprestriction was set to `^.*$` could not be edited. For now this displays as "any" for the IP restriction.