### PR TITLE
HT-2511 ht_institutions.enabled is not Boolean

### DIFF
--- a/app/models/ht_institution.rb
+++ b/app/models/ht_institution.rb
@@ -7,6 +7,8 @@ class HTInstitution < ApplicationRecord
   self.primary_key = 'inst_id'
   has_many :ht_users, foreign_key: :identity_provider, primary_key: :entityID
 
+  attribute :enabled, ActiveRecord::Type::Integer.new
+
   scope :enabled, -> { where('enabled = 1') }
   scope :other, -> { where('enabled != 1') }
 

--- a/app/models/ht_institution.rb
+++ b/app/models/ht_institution.rb
@@ -8,7 +8,7 @@ class HTInstitution < ApplicationRecord
   has_many :ht_users, foreign_key: :identity_provider, primary_key: :entityID
 
   scope :enabled, -> { where('enabled = 1') }
-  scope :disabled, -> { where('enabled != 1') }
+  scope :other, -> { where('enabled != 1') }
 
   # Checkpoint
   def resource_type

--- a/app/presenters/ht_institution_presenter.rb
+++ b/app/presenters/ht_institution_presenter.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class HTInstitutionPresenter
+  def self.badge_for(obj)
+    @badges ||= {
+      0 => "<span class='label label-danger'>#{I18n.t('ht_institution.badges.disabled')}</span>",
+      1 => "<span class='label label-success'>#{I18n.t('ht_institution.badges.enabled')}</span>",
+      2 => "<span class='label label-warning'>#{I18n.t('ht_institution.badges.private')}</span>",
+      3 => "<span class='label label-primary'>#{I18n.t('ht_institution.badges.social')}</span>"
+    }
+    return '' if obj.nil?
+
+    @badges&.[](obj.enabled)&.html_safe
+  end
+end

--- a/app/views/ht_institutions/index.html.erb
+++ b/app/views/ht_institutions/index.html.erb
@@ -39,10 +39,11 @@
       <th data-sortable="true">Name</th>
       <th data-sortable="true">Domain</th>
       <th data-sortable="true">US?</th>
+      <th data-sortable="true">Enabled?</th>
       <th data-sortable="true">Entity ID</th>
     </tr>
     </thead>
-    <% @institutions.disabled.each do |i| %>
+    <% @institutions.other.each do |i| %>
       <tr>
         <td><%= link_to i.inst_id, ht_institution_path(i.inst_id) %></td>
         <td><%= i.name %></td>
@@ -50,6 +51,7 @@
         <td>
           <%= raw i[:us] ? '<i class="glyphicon glyphicon-ok"></i>' : '' %>
         </td>
+        <td><%= HTInstitutionPresenter.badge_for(i) %></td>
         <td><%= i.entityID %></td>
       </tr>
     <% end %>

--- a/app/views/ht_institutions/show.html.erb
+++ b/app/views/ht_institutions/show.html.erb
@@ -9,11 +9,11 @@
       <dt>GRIN Instance:</dt> <dd><%= @institution.grin_instance %></dd>
       <dt>Name:</dt> <dd><%= @institution.name %></dd>
       <dt>US:</dt> <dd><%= raw @institution[:us] ? '<i class="glyphicon glyphicon-ok"></i>' : '' %></dd>
-      <dt>Enabled:</dt> <dd><%= raw @institution[:enabled] ? '<i class="glyphicon glyphicon-ok"></i>' : '' %></dd>
+      <dt>Enabled:</dt> <dd><%= HTInstitutionPresenter.badge_for(@institution) %></dd>
       <dt>Entity ID:</dt> <dd><%= @institution.entityID %></dd>
       <dt>Affiliations:</dt> <dd><%= @institution.allowed_affiliations %></dd>
       <dt>MFA auth context:</dt> <dd><%= @institution.shib_authncontext_class %></dd>
-      <dt>Affiliations for ETAS</dt> <dd><%= @institution.emergency_status %></dd>
+      <dt>Affiliations for ETAS:</dt> <dd><%= @institution.emergency_status %></dd>
       <dt>ETAS Contact:</dt> <dd><%= @institution.emergency_contact %></dd>
       <dt>Mapto Domain:</dt> <dd><%= @institution.mapto_domain %></dd>
       <dt>Mapto Inst ID:</dt> <dd><%= @institution.mapto_inst_id %></dd>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,6 +43,12 @@ en:
       renewed: "Renewed"
       sent: "Sent"
       unsent: "Unsent"
+  ht_institution:
+    badges:
+      disabled: "Disabled"
+      enabled: "Enabled"
+      private: "Private"
+      social: "Social Login"
   ht_user:
     edit:
       iprestrict_prompt: "If multiple IP addresses, enter as a comma-separated list."

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -47,7 +47,7 @@ ActiveRecord::Schema.define(version: 0) do # rubocop:disable Metrics/BlockLength
     t.string :mapto_inst_id
     t.string :mapto_name
     t.string :mapto_entityID
-    t.boolean :enabled
+    t.integer :enabled
     t.boolean :orph_agree
     t.string :entityID
     t.text :allowed_affiliations

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -32,7 +32,6 @@ def create_ht_user(expires:)
     u.identity_provider = HTInstitution.enabled.where.not(shib_authncontext_class: nil).sample.entityID
   else
     u.identity_provider = HTInstitution.enabled.sample.entityID
-    # Faker::Boolean.boolean(true_ratio: 0.2) fails with "ArgumentError (comparison of Float with Hash failed)"
     if rand > 0.4
       u.iprestrict = Faker::Internet.public_ip_v4_address
     elsif rand > 0.2
@@ -71,7 +70,7 @@ def create_ht_approval_request(user) # rubocop:disable Metrics/MethodLength
   ar.save!
 end
 
-10.times do
+def create_ht_institution(enabled) # rubocop:disable Metrics/MethodLength
   inst_id = Faker::Internet.unique.domain_word
   domain = inst_id + '.' + Faker::Internet.domain_suffix
   HTInstitution.create(
@@ -80,7 +79,7 @@ end
     authtype: ['', 'shibboleth'].sample,
     domain: domain,
     us: [0, 1].sample,
-    enabled: 1,
+    enabled: enabled,
     orph_agree: [0, 1].sample,
     entityID: Faker::Internet.url,
     allowed_affiliations: '^(alum|member)' + domain,
@@ -89,22 +88,20 @@ end
   )
 end
 
+10.times do
+  create_ht_institution(1)
+end
+
 2.times do
-  inst_id = Faker::Internet.unique.domain_word
-  domain = inst_id + '.' + Faker::Internet.domain_suffix
-  HTInstitution.create(
-    inst_id: inst_id,
-    name: Faker::University.name,
-    authtype: ['', 'shibboleth'].sample,
-    domain: domain,
-    us: [0, 1].sample,
-    enabled: 0,
-    orph_agree: [0, 1].sample,
-    entityID: Faker::Internet.url,
-    allowed_affiliations: '^(alum|member)@' + domain,
-    shib_authncontext_class: [nil, Faker::Internet.url].sample,
-    emergency_contact: Faker::Internet.email
-  )
+  create_ht_institution(0)
+end
+
+2.times do
+  create_ht_institution(2)
+end
+
+2.times do
+  create_ht_institution(3)
 end
 
 # We should simulate the typical situation in which some approvers are shared.

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -38,6 +38,22 @@ FactoryBot.define do
     trait :mfa do
       shib_authncontext_class { 'https://refeds.org/profile/mfa' }
     end
+
+    trait :disabled do
+      enabled { 0 }
+    end
+
+    trait :enabled do
+      enabled { 1 }
+    end
+
+    trait :private do
+      enabled { 2 }
+    end
+
+    trait :social do
+      enabled { 3 }
+    end
   end
 
   factory :ht_count do

--- a/test/models/ht_institution_test.rb
+++ b/test/models/ht_institution_test.rb
@@ -16,8 +16,8 @@ class HTInstitutionTest < ActiveSupport::TestCase
     assert_equal HTInstitution.enabled.first.inst_id, @enabled.inst_id
   end
 
-  test 'disabled scope' do
-    assert_equal HTInstitution.disabled.first.inst_id, @disabled.inst_id
+  test 'other scope' do
+    assert_equal HTInstitution.other.first.inst_id, @disabled.inst_id
   end
 
   test 'correct Checkpoint resource_type and resource_id' do

--- a/test/presenters/ht_institution_presenter_test.rb
+++ b/test/presenters/ht_institution_presenter_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class HTInstitutionresenterTest < ActiveSupport::TestCase
+  test 'disabled badge' do
+    req = build(:ht_institution, :disabled)
+    assert_not_nil HTInstitutionPresenter.badge_for(req)
+    assert_match 'Disabled', HTInstitutionPresenter.badge_for(req)
+  end
+
+  test 'enabled badge' do
+    req = build(:ht_institution, :enabled)
+    assert_not_nil HTInstitutionPresenter.badge_for(req)
+    assert_match 'Enabled', HTInstitutionPresenter.badge_for(req)
+  end
+
+  test 'private badge' do
+    req = build(:ht_institution, :private)
+    assert_not_nil HTInstitutionPresenter.badge_for(req)
+    assert_match 'Private', HTInstitutionPresenter.badge_for(req)
+  end
+
+  test 'social badge' do
+    req = build(:ht_institution, :social)
+    assert_not_nil HTInstitutionPresenter.badge_for(req)
+    assert_match 'Social', HTInstitutionPresenter.badge_for(req)
+  end
+end


### PR DESCRIPTION
- `ht_institution.enabled` redefined as an integer.
- Make sure suitable examples are in seeded database.
- Add `HTInstitutionPresenter` status badges for index and show pages.

Deployed to useradmin-staging but badges are not showing up, possibly because the schema still has `enabled` as a Boolean somewhere.