### PR TITLE
HT-2468 one-time use links should not show menu links that are unauthorized

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  def nav_menu
+    %w[users approval_requests institutions]
+      .select { |item| can?(:index, "ht_#{item}") }
+      .map { |item| [item.titleize, send("ht_#{item}_path")] }
+  end
 end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -3,39 +3,29 @@
   <% unless logged_in? %>
       <p class="navbar-text">Not signed in</p>
   <% else %>
-
-    <% # Links menu will be empty when an external approver comes in.%>
-    <% # In that case we don't display any of the navigation bits. %>
-    <% nav_menu = [] %>
-    <% [['Users', 'users'],
-        ['Approval Requests', 'approval_requests'],
-        ['Institutions', 'institutions']].each do |item| %>
-      <% if can?(:index, "ht_#{item[1]}".to_sym) %>
-        <% nav_menu << [item[0], self.send("ht_#{item[1]}_path")] %>
-      <% end %>
-    <% end %>
-
     <p class="navbar-text"><%= "Signed in as #{current_user.id}" %></p>
     <div class="collapse navbar-collapse">
       <ul class="nav navbar-nav">
         <% unless Rails.env.production? %>
         <li><%= link_to "Log Out", logout_path %></li>
         <% end %>
-        <% if nav_menu.count.positive? %>
-          <li><%= link_to "Home", controller.default_path %></li>
-          <li class="dropdown">
-            <a href="#" class="dropdown-toggle" data-toggle="dropdown"
-               role="button" aria-haspopup="true" aria-expanded="false">
-               Go <span class="caret"></span>
-            </a>
-            <ul class="dropdown-menu">
-              <% nav_menu.each do |item| %>
-                <li><a href="#"><%= link_to item[0], item[1] %></a></li>
-              <% end %>
-              <!--<li role="separator" class="divider"></li>-->
-            </ul>
-          </li>
-         <% end %>
+        <% nav_menu.tap do |nav| %>
+          <% if nav.any? %>
+            <li><%= link_to "Home", controller.default_path %></li>
+            <li class="dropdown">
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown"
+                 role="button" aria-haspopup="true" aria-expanded="false">
+                 Go <span class="caret"></span>
+              </a>
+              <ul class="dropdown-menu">
+                <% nav.each do |item| %>
+                  <li><a href="#"><%= link_to item[0], item[1] %></a></li>
+                <% end %>
+                <!--<li role="separator" class="divider"></li>-->
+              </ul>
+            </li>
+           <% end %>
+        <% end %>
       </ul>
     </div>
   <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,33 +1,43 @@
 <nav class="navbar navbar-default">
   <div class="container-fluid">
-<% unless logged_in? %>
-    <p class="navbar-text">Not signed in</p>
-<% else %>
+  <% unless logged_in? %>
+      <p class="navbar-text">Not signed in</p>
+  <% else %>
+
+    <% # Links menu will be empty when an external approver comes in.%>
+    <% # In that case we don't display any of the navigation bits. %>
+    <% nav_menu = [] %>
+    <% [['Users', 'users'],
+        ['Approval Requests', 'approval_requests'],
+        ['Institutions', 'institutions']].each do |item| %>
+      <% if can?(:index, "ht_#{item[1]}".to_sym) %>
+        <% nav_menu << [item[0], self.send("ht_#{item[1]}_path")] %>
+      <% end %>
+    <% end %>
+
     <p class="navbar-text"><%= "Signed in as #{current_user.id}" %></p>
     <div class="collapse navbar-collapse">
       <ul class="nav navbar-nav">
         <% unless Rails.env.production? %>
         <li><%= link_to "Log Out", logout_path %></li>
         <% end %>
-        <li><%= link_to "Home", controller.default_path %></li>
-        <li class="dropdown">
-          <a href="#" class="dropdown-toggle" data-toggle="dropdown"
-             role="button" aria-haspopup="true" aria-expanded="false">
-             Go <span class="caret"></span>
-          </a>
-          <ul class="dropdown-menu">
-            <% [['Users', 'users'],
-                ['Approval Requests', 'approval_requests'],
-                ['Institutions', 'institutions']].each do |item| %>
-              <% if can?(:index, "ht_#{item[1]}".to_sym) %>
-                <li><a href="#"><%= link_to item[0], self.send("ht_#{item[1]}_path") %></a></li>
+        <% if nav_menu.count.positive? %>
+          <li><%= link_to "Home", controller.default_path %></li>
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown"
+               role="button" aria-haspopup="true" aria-expanded="false">
+               Go <span class="caret"></span>
+            </a>
+            <ul class="dropdown-menu">
+              <% nav_menu.each do |item| %>
+                <li><a href="#"><%= link_to item[0], item[1] %></a></li>
               <% end %>
-            <% end %>
-            <!--<li role="separator" class="divider"></li>-->
-          </ul>
-        </li>
+              <!--<li role="separator" class="divider"></li>-->
+            </ul>
+          </li>
+         <% end %>
       </ul>
     </div>
-<% end %>
+  <% end %>
   </div>
 </nav>

--- a/test/controllers/approval_controller_test.rb
+++ b/test/controllers/approval_controller_test.rb
@@ -19,6 +19,13 @@ class ApprovalControllerTest < ActionDispatch::IntegrationTest
     assert_equal Date.parse(@req.reload.received).to_s, Date.parse(Time.zone.now.to_s).to_s
   end
 
+  test 'does not show nav menu for approval with email not known in advance' do
+    sign_in! username: Faker::Internet.email
+    get approve_url @req.token
+    assert_response :success
+    assert_no_match 'Home', @response.body
+  end
+
   test 'refuses to approve the same request a second time' do
     sign_in!
     get approve_url @req.token

--- a/test/controllers/ht_users_controller_test.rb
+++ b/test/controllers/ht_users_controller_test.rb
@@ -20,6 +20,12 @@ class HTUsersControllerTest < ActionDispatch::IntegrationTest
     assert_match @user2.email, @response.body
   end
 
+  test 'shows nav menu' do
+    sign_in!
+    get ht_users_url
+    assert_match('Approval Requests', @response.body)
+  end
+
   test 'should get show page' do
     sign_in!
     get ht_user_url @user1


### PR DESCRIPTION
Construct the nav structure at a higher level than before and suppress the Home link and Go menu when the structure is empty.