### PR TITLE
Use MariaDB for dev & test; add editing for billing members fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,11 @@ jobs:
       - name: Set up tests
         run: |
           docker-compose build
-          docker-compose run web bundle install
-          docker-compose run web bundle exec rake keycard:migrate RAILS_ENV=test
-          docker-compose run web bundle exec rake checkpoint:migrate RAILS_ENV=test
-          docker-compose run -e RAILS_ENV=test web bundle exec rails db:setup
+          docker-compose run test bundle install
 
       - name: Run rubocop
-        run: docker-compose run web bundle exec rubocop
+        run: docker-compose run test bundle exec rubocop
 
       - name: Run tests
-        run: docker-compose run web bundle exec rails test
+        run: docker-compose run test
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,17 +4,18 @@ ARG UID=1000
 ARG GID=1000
 
 RUN apt-get update -yqq && apt-get install -yqq --no-install-recommends \
-  nodejs
+  nodejs \
+  netcat
 
 # COPY Gemfile* /usr/src/app/
 WORKDIR /usr/src/app
-# 
+#
 ENV BUNDLE_PATH /gems
-# 
+#
 RUN gem install bundler
-# 
+#
 # COPY . /usr/src/app
 
-CMD ["bin/rails", "s", "-b", "0.0.0.0"]
+CMD ["bin/rails","s","-b","0.0.0.0"]
 
 

--- a/README.md
+++ b/README.md
@@ -1,48 +1,32 @@
-# Otis Elevated Access Tool
+# Otis Administrative Tools
 
 ## Initial setup
-### 1. Getting a local copy, bundle install gems, and execute setup script
+### 1. Set up development
 
 ```
 $ git clone https://github.com/hathitrust/otis.git
 $ cd otis
-$ bundle install
+$ docker-compose build
+$ docker-compose run web bundle install
 ```
 
-### 2. Database
-
-Development mode uses sqlite3 with generated data. The keycard and
-checkpoint databases also need to be set up. The `otis:migrate_users` task
-sets up three dummy users with different levels of access (this is done
-automatically for the `test` environment by the test script).
+### 2. Trying it out
 
 ```
-bundle exec rake keycard:migrate RAILS_ENV=development
-bundle exec rake keycard:migrate RAILS_ENV=test
-bundle exec rake checkpoint:migrate RAILS_ENV=development
-bundle exec rake checkpoint:migrate RAILS_ENV=test
-bundle exec rake db:setup
-bundle exec rake otis:migrate_users RAILS_ENV=development
+docker-compose up -d web
 ```
 
-### 3. Testing
+Development mode uses mysql via Docker with generated data from the `db:seed`
+task and three dummy users with different levels of access via the
+`otis:migrate_users` task. Starting the web container automatically runs these
+tasks via `bin/init_dev_db.sh`.
+
+To try the application, go to http://localhost:3000/useradmin and log in as one
+of `{admin,staff,institution}@default.invalid`, in decreasing order of
+administrative power.
+
+### 3. Running tests
 
 ```
-bundle exec rake test
+docker-compose run test
 ```
-
-### 4. Trying it out
-
-```
-bundle exec rails s
-```
-
-Go to http://localhost:3000/useradmin and log in as one of
-`{admin,staff,institution}@default.invalid`,
-in decreasing order of administrative power.
-
-### 5. Staged version
-
-* Living at https://moseshll.babel.hathitrust.org/useradmin-staging
-* Deploy via moku with ssh deployhost-001 deploy useradmin-staging the-name-of-your-branch
-

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -90,4 +90,22 @@ class ApplicationController < ActionController::Base
       ]
     )
   end
+
+  # Adapted from https://gist.github.com/redrick/2c23988368fb525c7e75
+  # there is more there, including GeoIP which we may use as when we
+  # address HT-1451
+  def log_action(log_entry, permitted_params)
+    raise UnfilteredParameters unless permitted_params.permitted?
+
+    rails_action = "#{params[:controller]}##{params[:action]}"
+
+    log_entry.data = {
+      action: rails_action,
+      ip_address: request.remote_ip,
+      params: permitted_params,
+      user_agent: request.user_agent
+    }.merge(keycard_attributes)
+    log_entry.save
+    Rails.logger.info "AUDIT LOG: #{JSON.generate(log_entry.data)}"
+  end
 end

--- a/app/controllers/approval_controller.rb
+++ b/app/controllers/approval_controller.rb
@@ -28,23 +28,8 @@ class ApprovalController < ApplicationController
   def approve
     @req.received = Time.zone.now
     @req.save!
-    log
-  end
-
-  # Adapted from https://gist.github.com/redrick/2c23988368fb525c7e75
-  # there is more there, including GeoIP which we may use as when we
-  # address HT-1451
-  def log
-    rails_action = "#{params[:controller]}##{params[:action]}"
-    rails_params = params.except(:controller, :action, :token)
-
-    details = {
-      action: rails_action,
-      ip_address: request.remote_ip,
-      params: rails_params,
-      user_agent: request.user_agent
-    }.merge(keycard_attributes)
-    HTUserLog.create(ht_user: @user, data: details)
-    Rails.logger.info "APPROVAL LOG: #{JSON.generate(details)}"
+    # Currently, there are no parameters for the controller other than the
+    # token, which we do not wish to log.
+    log_action(HTUserLog.new(ht_user: @user), params.permit)
   end
 end

--- a/app/controllers/ht_institutions_controller.rb
+++ b/app/controllers/ht_institutions_controller.rb
@@ -17,12 +17,21 @@ class HTInstitutionsController < ApplicationController
     us
   ].freeze
 
+  PERMITTED_BILLING_FIELDS = %i[
+    weight
+    oclc_sym
+    marc21_sym
+    country_code
+    status
+  ].freeze
+
   PERMITTED_CREATE_FIELDS = PERMITTED_UPDATE_FIELDS + %i[inst_id]
 
   def new
     @institution = HTInstitutionPresenter.new(HTInstitution.new)
 
     @institution.set_defaults_for_entity(params[:entityID]) if params[:entityID]
+    @institution.ht_billing_member = HTBillingMember.new
   end
 
   def index
@@ -56,7 +65,7 @@ class HTInstitutionsController < ApplicationController
 
   def inst_params(permitted_fields)
     @inst_params ||= params.require(:ht_institution)
-                           .permit(*permitted_fields)
+                           .permit(*permitted_fields, ht_billing_member_attributes: PERMITTED_BILLING_FIELDS)
                            .transform_values! { |v| v.present? ? v : nil }
   end
 

--- a/app/controllers/ht_institutions_controller.rb
+++ b/app/controllers/ht_institutions_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class HTInstitutionsController < ApplicationController
-  before_action :fetch_institution, only: %i[show edit update]
+  before_action :fetch_institution, only: %i[show edit]
 
   PERMITTED_UPDATE_FIELDS = %i[
     grin_instance
@@ -40,7 +40,10 @@ class HTInstitutionsController < ApplicationController
   end
 
   def update
+    @institution = HTInstitution.find(params[:id])
+
     if @institution.update(inst_params(PERMITTED_UPDATE_FIELDS))
+      log
       flash[:notice] = 'Institution updated'
       redirect_to @institution
     else
@@ -51,9 +54,10 @@ class HTInstitutionsController < ApplicationController
   end
 
   def create
-    @institution = HTInstitutionPresenter.new(HTInstitution.new(inst_params(PERMITTED_CREATE_FIELDS)))
+    @institution = HTInstitution.new(inst_params(PERMITTED_CREATE_FIELDS))
 
     if @institution.save
+      log
       redirect_to @institution, note: 'Institution was successfully created'
     else
       flash.now[:alert] = @institution.errors.full_messages.to_sentence
@@ -62,6 +66,10 @@ class HTInstitutionsController < ApplicationController
   end
 
   private
+
+  def log
+    log_action(HTInstitutionLog.new(ht_institution: @institution), @inst_params)
+  end
 
   def inst_params(permitted_fields)
     @inst_params ||= params.require(:ht_institution)

--- a/app/models/ht_billing_member.rb
+++ b/app/models/ht_billing_member.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class HTBillingMember < ApplicationRecord
+  belongs_to :ht_institution, foreign_key: 'inst_id', optional: true
+
+  self.primary_key = 'inst_id'
+end

--- a/app/models/ht_institution.rb
+++ b/app/models/ht_institution.rb
@@ -6,6 +6,7 @@ class HTInstitution < ApplicationRecord
 
   self.primary_key = 'inst_id'
   has_many :ht_users, foreign_key: :identity_provider, primary_key: :entityID
+  has_many :ht_institution_log, foreign_key: :inst_id, primary_key: :inst_id
 
   validates :inst_id, presence: true, uniqueness: true
   validates :name, presence: true

--- a/app/models/ht_institution.rb
+++ b/app/models/ht_institution.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-# We're not really interested in editing or viewing this table,
-# but we want to allow HTUser access to a human-readable version of
-# the institution.
 class HTInstitution < ApplicationRecord
+  has_one :ht_billing_member, foreign_key: 'inst_id'
+  accepts_nested_attributes_for :ht_billing_member
+
   self.primary_key = 'inst_id'
   has_many :ht_users, foreign_key: :identity_provider, primary_key: :entityID
 

--- a/app/models/ht_institution_log.rb
+++ b/app/models/ht_institution_log.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class HTInstitutionLog < ApplicationRecord
+  belongs_to :ht_institution, foreign_key: :inst_id, primary_key: :inst_id
+
+  validates :inst_id, presence: true
+  validates :data, presence: true
+
+  serialize :data, JSON
+
+  attribute :time, default: -> { Time.zone.now }
+end

--- a/app/presenters/ht_institution_presenter.rb
+++ b/app/presenters/ht_institution_presenter.rb
@@ -43,11 +43,15 @@ class HTInstitutionPresenter < SimpleDelegator
   end
 
   def us_icon
-    raw us ? '<i class="glyphicon glyphicon-ok"></i>' : ''
+    checkmark_icon(us)
   end
 
   def etas_active_icon
-    raw emergency_status ? '<i class="glyphicon glyphicon-ok"></i>' : ''
+    checkmark_icon(emergency_status)
+  end
+
+  def billing_enabled_icon
+    checkmark_icon(ht_billing_member&.status)
   end
 
   def formatted_mapto_name
@@ -95,6 +99,10 @@ class HTInstitutionPresenter < SimpleDelegator
   end
 
   private
+
+  def checkmark_icon(field)
+    raw field ? '<i class="glyphicon glyphicon-ok"></i>' : ''
+  end
 
   def controller
     # required for url helpers to work

--- a/app/views/ht_institutions/_form.html.erb
+++ b/app/views/ht_institutions/_form.html.erb
@@ -41,9 +41,22 @@
         <dt>ETAS Contact:</dt>
         <dd><%= form.text_field :emergency_contact, size: 40 %></dd>
 
-        <dt>Enabled:</dt> <dd>
+        <dt>Enabled for Login:</dt> <dd>
         <%= form.select :enabled, @institution.badge_options %>
         </dd>
+
+        <%= form.fields_for :ht_billing_member do |billing_form| %>
+        <dt>Weight:</dt>
+        <dd><%= billing_form.text_field :weight, size:8 %>
+        <dt>OCLC Symbol:</dt>
+        <dd><%= billing_form.text_field :oclc_sym, size:8 %> (<a target="_new" href="https://www.oclc.org/en/contacts/libraries.html">Lookup</a>)
+        <dt>MARC Code:</dt>
+        <dd><%= billing_form.text_field :marc21_sym, size:8 %> (<a target="_new" href="https://www.loc.gov/marc/organizations/">Lookup</a>)
+        <dt>Country Code:</dt>
+        <dd><%= billing_form.text_field :country_code, size:8 %> (<a target="_new" href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">Lookup</a>)
+        <dt>Enabled for Billing:</dt>
+        <dd><%= billing_form.check_box :status %></dd>
+        <% end %>
 
       </dl>
 

--- a/app/views/ht_institutions/index.html.erb
+++ b/app/views/ht_institutions/index.html.erb
@@ -59,24 +59,26 @@
 
   <br />
 
-  <h2> Add New Institution </h2>
+  <% if can?(:create, :ht_institutions) %>
+    <h2> Add New Institution </h2>
 
-  <p> <a target="_blank" href="https://met.refeds.org">Search REFEDS Metadata Explorer (opens in new tab)</a> for a SAML
-  entity ID and enter it here to pre-populate the institution data:
+    <p> <a target="_blank" href="https://met.refeds.org">Search REFEDS Metadata Explorer (opens in new tab)</a> for a SAML
+    entity ID and enter it here to pre-populate the institution data:
 
-  <%= form_with url: new_ht_institution_path, method: :get, local: true do |form| %>
-    <%= form.label :entityID, "Entity ID:" %>
-    <%= form.text_field :entityID, size: 40 %>
-    <%= form.submit "Load Metadata", class: 'btn btn-primary' %>
+    <%= form_with url: new_ht_institution_path, method: :get, local: true do |form| %>
+      <%= form.label :entityID, "Entity ID:" %>
+      <%= form.text_field :entityID, size: 40 %>
+      <%= form.submit "Load Metadata", class: 'btn btn-primary' %>
+    <% end %>
+
+    </p>
+
+    <p> Or, manually provide the information:
+
+    <%= link_to 'Add New Instititution', new_ht_institution_path, class: 'btn btn-primary' %>
+
+    </p>
   <% end %>
-
-  </p>
-
-  <p> Or, manually provide the information:
-
-  <%= link_to 'Add New Instititution', new_ht_institution_path, class: 'btn btn-primary' %>
-
-  </p>
 
 </div>
 

--- a/app/views/ht_institutions/show.html.erb
+++ b/app/views/ht_institutions/show.html.erb
@@ -23,6 +23,7 @@
       <dt>Affiliations for ETAS:</dt> <dd><%= @institution.etas_affiliations %></dd>
       <dt>ETAS Contact:</dt> <dd><%= @institution.emergency_contact_link %></dd>
       <dt>Enabled for Login:</dt> <dd><%= @institution.badge %></dd>
+      <dt>Last Updated:</dt> <dd><%= @institution.last_update %></dd>
 
       <% if(@institution.ht_billing_member) %>
         <dt>Weight:</dt> <dd><%= @institution.ht_billing_member.weight %></dd>

--- a/app/views/ht_institutions/show.html.erb
+++ b/app/views/ht_institutions/show.html.erb
@@ -16,13 +16,21 @@
       <dd><%= @institution.mapped_inst_link %>
     <!--    <p><small>The ID of the institution submitting holdings including this partner. In most cases it is the same as the institution itself. For university systems with separate login for each campus but combined holdings, this should be the ID of the system.</small></p> -->
       </dd>
-      <dt>US:</dt> <dd><%= raw @institution[:us] ? '<i class="glyphicon glyphicon-ok"></i>' : '' %></dd>
+      <dt>US:</dt> <dd><%= @institution.us_icon %></dd>
       <dt>GRIN Instance:</dt> <dd><%= @institution.grin_link %></dd>
       <dt>MFA auth context:</dt> <dd> <%= @institution.shib_authncontext_class %> </dd>
       <dt>Affiliations:</dt> <dd><%= @institution.allowed_affiliations %></dd>
       <dt>Affiliations for ETAS:</dt> <dd><%= @institution.etas_affiliations %></dd>
       <dt>ETAS Contact:</dt> <dd><%= @institution.emergency_contact_link %></dd>
-      <dt>Enabled:</dt> <dd><%= @institution.badge %></dd>
+      <dt>Enabled for Login:</dt> <dd><%= @institution.badge %></dd>
+
+      <% if(@institution.ht_billing_member) %>
+        <dt>Weight:</dt> <dd><%= @institution.ht_billing_member.weight %></dd>
+        <dt>OCLC Symbol:</dt> <dd><%= @institution.ht_billing_member.oclc_sym %></dd>
+        <dt>MARC Code:</dt> <dd><%= @institution.ht_billing_member.marc21_sym %></dd>
+        <dt>Country Code:</dt> <dd><%= @institution.ht_billing_member.country_code %></dd>
+        <dt>Enabled for Billing:</dt> <dd><%= @institution.billing_enabled_icon %></dd>
+      <% end %>
     </dl>
 
    <br />

--- a/bin/init_dev_db.sh
+++ b/bin/init_dev_db.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+bin/wait-for mariadb-dev:3306
+bundle exec rake keycard:migrate RAILS_ENV=development
+bundle exec rake checkpoint:migrate RAILS_ENV=development
+bundle exec rake db:seed
+bundle exec rake otis:migrate_users RAILS_ENV=development

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+export RAILS_ENV=test
+
+bin/wait-for mariadb-test:3306
+bundle exec rake test

--- a/bin/wait-for
+++ b/bin/wait-for
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+# From https://github.com/eficode/wait-for
+
+# The MIT License (MIT)
+#
+# Copyright (c) 2017 Eficode Oy
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+TIMEOUT=15
+QUIET=0
+
+echoerr() {
+  if [ "$QUIET" -ne 1 ]; then printf "%s\n" "$*" 1>&2; fi
+}
+
+usage() {
+  exitcode="$1"
+  cat << USAGE >&2
+Usage:
+  $cmdname host:port [host:port ...] [-t timeout] [-- command args]
+  -q | --quiet                        Do not output any status messages
+  -t TIMEOUT | --timeout=timeout      Timeout in seconds, zero for no timeout
+  -- COMMAND ARGS                     Execute command with args after the test finishes
+USAGE
+  exit "$exitcode"
+}
+
+wait_for() {
+  command="$*"
+  for i in `seq $TIMEOUT` ; do
+
+    result=0
+
+    for dep in $DEPENDENCIES; do
+      host=$(printf "%s\n" "$dep"| cut -d : -f 1)
+      port=$(printf "%s\n" "$dep"| cut -d : -f 2)
+      if [ "$host" = "" -o "$port" = "" ]; then
+        echoerr "Error: you need to provide a host and port to test."
+        usage 2
+      fi
+      nc -z "$host" "$port" > /dev/null 2>&1
+      nc_result=$?
+      if [ $nc_result -ne 0 ] ; then
+        result=1
+      fi
+    done
+
+    if [ $result -eq 0 ] ; then
+      if [ -n "$command" ] ; then
+        exec $command
+      fi
+      exit 0
+    fi
+    sleep 1
+  done
+  echo "Operation timed out" >&2
+  exit 1
+}
+
+DEPENDENCIES=""
+while [ $# -gt 0 ]
+do
+  case "$1" in
+    *:* )
+    DEPENDENCIES+=" $1"
+    shift 1
+    ;;
+    -q | --quiet)
+    QUIET=1
+    shift 1
+    ;;
+    -t)
+    TIMEOUT="$2"
+    if [ "$TIMEOUT" = "" ]; then break; fi
+    shift 2
+    ;;
+    --timeout=*)
+    TIMEOUT="${1#*=}"
+    shift 1
+    ;;
+    --)
+    shift
+    break
+    ;;
+    --help)
+    usage 0
+    ;;
+    *)
+    echoerr "Unknown argument: $1"
+    usage 1
+    ;;
+  esac
+done
+
+if [ "${#DEPENDENCIES[@]}" -eq "0" ]; then
+  echoerr "Error: you need to provide a host and port to test."
+  usage 2
+fi
+
+wait_for "$@"

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,5 +29,6 @@ module Otis
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+    config.time_zone = 'America/Detroit'
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -8,20 +8,23 @@
 # Use mysql2 as the database for Active Record
 #
 default: &default
-  adapter: sqlite3
+  adapter: mysql2
+  database: ht
+  username: otis
+  password: otis
   encoding: utf8
   pool: 5
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  host: mariadb-dev
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  host: mariadb-test
 
 # Warning: Do not set username and password in the file!
 # Assign username and password to environment variables.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,6 +41,8 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
+  config.time_zone = 'UTC'
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -3,13 +3,19 @@ relative_url_root: '/useradmin'
 
 keycard:
   database:
-    adapter: sqlite
-    database: tmp/keycard_dev.sqlite3
+    adapter: mysql2
+    database: ht
+    username: otis
+    password: otis
+    host: mariadb-dev
 
 checkpoint:
   database:
-    adapter: sqlite
-    database: tmp/checkpoint_dev.sqlite3
+    adapter: mysql2
+    database: ht
+    username: otis
+    password: otis
+    host: mariadb-dev
 
 # Superuser account
 users:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -17,13 +17,19 @@ relative_url_root: '/'
 
 keycard:
   database:
-    adapter: sqlite
-    database: tmp/keycard_test.sqlite3
+    adapter: mysql2
+    database: ht
+    username: otis
+    password: otis
+    host: mariadb-test
 
 checkpoint:
   database:
-    adapter: sqlite
-    database: tmp/checkpoint_test.sqlite3
+    adapter: mysql2
+    database: ht
+    username: otis
+    password: otis
+    host: mariadb-test
 
 shibboleth:
   url: /useradmin/Shibboleth.sso/Login

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -81,6 +81,12 @@ ActiveRecord::Schema.define(version: 0) do # rubocop:disable Metrics/BlockLength
     t.text :data
   end
 
+  create_table :ht_institution_logs do |t|
+    t.string :inst_id
+    t.timestamp :time
+    t.text :data
+  end
+
   create_table :ht_billing_members, id: false do |t|
     t.string :inst_id, primary_key: true
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -54,6 +54,7 @@ ActiveRecord::Schema.define(version: 0) do # rubocop:disable Metrics/BlockLength
     t.string :shib_authncontext_class
     t.text :emergency_status
     t.string :emergency_contact
+    t.timestamp :last_updated
   end
 
   create_table :ht_counts, id: false do |t|
@@ -78,5 +79,15 @@ ActiveRecord::Schema.define(version: 0) do # rubocop:disable Metrics/BlockLength
     t.string :userid
     t.timestamp :time
     t.text :data
+  end
+
+  create_table :ht_billing_members, id: false do |t|
+    t.string :inst_id, primary_key: true
+
+    t.column :weight, :decimal, precision: 4, scale: 2
+    t.string :oclc_sym
+    t.string :marc21_sym
+    t.string :country_code
+    t.boolean :status
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -54,7 +54,7 @@ ActiveRecord::Schema.define(version: 0) do # rubocop:disable Metrics/BlockLength
     t.string :shib_authncontext_class
     t.text :emergency_status
     t.string :emergency_contact
-    t.timestamp :last_updated
+    t.timestamp :last_update
   end
 
   create_table :ht_counts, id: false do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -61,6 +61,7 @@ def create_ht_approval_request(user) # rubocop:disable Metrics/MethodLength
   received = sent.nil? ? nil : [nil, sent + Faker::Number.within(range: 1..10).days].sample
   renewed = received.nil? ? nil : [nil, received + Faker::Number.within(range: 1..10).days].sample
   ar = HTApprovalRequest.new(
+    id: Faker::Number.unique.number(digits: 9),
     approver: user.approver,
     userid: user.email,
     received: received,
@@ -86,10 +87,23 @@ def create_ht_institution(enabled) # rubocop:disable Metrics/MethodLength
     shib_authncontext_class: [nil, Faker::Internet.url].sample,
     emergency_contact: Faker::Internet.email
   )
+  inst_id
+end
+
+def create_ht_billing_member(inst_id)
+  HTBillingMember.create(
+    inst_id: inst_id,
+    weight: Faker::Number.within(range: 0.0..1.0),
+    oclc_sym: Faker::Alphanumeric.alpha(number: Faker::Number.between(from: 3, to: 5)),
+    marc21_sym: Faker::Alphanumeric.alpha(number: 3).upcase,
+    country_code: Faker::Address.country_code,
+    status: 1
+  )
 end
 
 10.times do
-  create_ht_institution(1)
+  inst_id = create_ht_institution(1)
+  create_ht_billing_member(inst_id) if [0, 1].sample.zero?
 end
 
 2.times do

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,39 @@ services:
     volumes:
       - .:/usr/src/app
       - gem_cache:/gems
+    depends_on:
+      - mariadb-dev
+    command: bash -c "bin/init_dev_db.sh && bundle exec rails s -b 0.0.0.0"
 
+  test:
+    build: .
+    volumes:
+      - .:/usr/src/app
+      - gem_cache:/gems
+    depends_on:
+      - mariadb-test
+    command: bash -c "bin/wait-for mariadb-test:3306 && bundle exec rake test"
+    deploy:
+      restart_policy:
+        condition: none
+
+  mariadb-dev:
+    image: hathitrust/db-image
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: mysqlroot
+      MYSQL_DATABASE: ht
+      MYSQL_USER: otis
+      MYSQL_PASSWORD: otis
+
+  mariadb-test:
+    image: hathitrust/db-image
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: mysqlroot
+      MYSQL_DATABASE: ht
+      MYSQL_USER: otis
+      MYSQL_PASSWORD: otis
 
 volumes:
   gem_cache:

--- a/test/controllers/ht_institutions_controller_test.rb
+++ b/test/controllers/ht_institutions_controller_test.rb
@@ -203,6 +203,13 @@ class HTInstitutionsControllerCreateTest < ActionDispatch::IntegrationTest
     assert_redirected_to ht_institution_url(inst_id)
     assert_equal(HTInstitution.find(inst_id).ht_billing_member.marc21_sym, billing_params[:marc21_sym])
   end
+
+  test 'logs creation' do
+    inst_params = attributes_for(:ht_institution)
+    inst_id = inst_params[:inst_id]
+    post ht_institutions_url, params: { ht_institution: inst_params }
+    assert_equal(inst_id, HTInstitution.find(inst_id).ht_institution_log.first.data['params']['inst_id'])
+  end
 end
 
 class HTInstitutionsControllerEditTest < ActionDispatch::IntegrationTest
@@ -245,5 +252,16 @@ class HTInstitutionsControllerEditTest < ActionDispatch::IntegrationTest
     follow_redirect!
 
     assert_nil HTInstitution.find(inst.inst_id).emergency_status
+  end
+
+  test 'logs ETAS enabling with affiliation and time' do
+    new_status = '^(member)@university.invalid'
+    inst = create(:ht_institution, emergency_status: nil)
+    patch ht_institution_url inst, params: {'ht_institution' => {'emergency_status' => new_status}}
+
+    log = HTInstitution.find(inst.inst_id).ht_institution_log.first
+
+    assert_not_nil(log.time)
+    assert_equal(new_status, log.data['params']['emergency_status'])
   end
 end

--- a/test/controllers/ht_institutions_controller_test.rb
+++ b/test/controllers/ht_institutions_controller_test.rb
@@ -51,10 +51,11 @@ class HTInstitutionsShowTest < ActionDispatch::IntegrationTest
     @inst = create(:ht_institution)
     @mfa_inst = create(:ht_institution, name: 'MFA University', enabled: true,
            shib_authncontext_class: 'https://refeds.org/profile/mfa')
+
+    sign_in!
   end
 
   test 'should get show page' do
-    sign_in!
     get ht_institution_url @inst
     assert_response :success
     assert_not_nil assigns(:institution)
@@ -62,22 +63,27 @@ class HTInstitutionsShowTest < ActionDispatch::IntegrationTest
   end
 
   test 'shows institution name and id' do
-    sign_in!
     get ht_institution_url @inst
     assert_match @inst.inst_id, @response.body
     assert_match ERB::Util.html_escape(@inst.name), @response.body
   end
 
   test 'Shows whoami link' do
-    sign_in!
     get ht_institution_url @inst
     assert_match(%r{/cgi/whoami}m, @response.body)
   end
 
   test 'With MFA auth context, shows whoami link with step-up MFA' do
-    sign_in!
     get ht_institution_url @mfa_inst
     assert_match(%r{authnContextClassRef=https://refeds.org/profile/mfa}m, @response.body)
+  end
+
+  test 'shows billing member info' do
+    billing_member = create(:ht_billing_member, inst_id: @inst.inst_id)
+
+    get ht_institution_url @inst
+    assert_match(/#{billing_member.oclc_sym}/, @response.body)
+    assert_match(/#{billing_member.marc21_sym}/, @response.body)
   end
 end
 
@@ -148,14 +154,16 @@ class HTInstitutionsControllerRolesTest < ActionDispatch::IntegrationTest
 end
 
 class HTInstitutionsControllerCreateTest < ActionDispatch::IntegrationTest
-  test 'inst id is editable for new institution' do
+  setup do
     sign_in! username: 'admin@default.invalid'
+  end
+
+  test 'inst id is editable for new institution' do
     get new_ht_institution_url
     assert_select 'input[name="ht_institution[inst_id]"]'
   end
 
   test 'us is selectable' do
-    sign_in! username: 'admin@default.invalid'
     get new_ht_institution_url
     assert_select 'input[name="ht_institution[us]"]'
   end
@@ -163,20 +171,48 @@ class HTInstitutionsControllerCreateTest < ActionDispatch::IntegrationTest
   test 'Can create' do
     inst_params = attributes_for(:ht_institution)
     inst_id = inst_params[:inst_id]
-    sign_in! username: 'admin@default.invalid'
     post ht_institutions_url, params: {ht_institution: inst_params}
 
     assert_redirected_to ht_institution_url(inst_id)
 
     assert_not_nil(HTInstitution.find(inst_id))
   end
+
+  test 'marc org code editable for new institution' do
+    get new_ht_institution_url
+    assert_select 'input[name="ht_institution[ht_billing_member_attributes][marc21_sym]"]'
+  end
+
+  test 'saves marc code for new institution' do
+    inst_params = attributes_for(:ht_institution)
+    inst_id = inst_params[:inst_id]
+    billing_params = attributes_for(:ht_billing_member)
+
+    post ht_institutions_url, params: {
+      ht_institution: {
+        inst_id: inst_params[:inst_id],
+        name: inst_params[:name],
+        enabled: inst_params[:enabled],
+        ht_billing_member_attributes: {
+          marc21_sym: billing_params[:marc21_sym],
+          status: false
+        }
+      }
+    }
+
+    assert_redirected_to ht_institution_url(inst_id)
+    assert_equal(HTInstitution.find(inst_id).ht_billing_member.marc21_sym, billing_params[:marc21_sym])
+  end
 end
 
 class HTInstitutionsControllerEditTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in! username: 'admin@default.invalid'
+  end
+
   test 'Editable fields present' do
     EDITABLE_FIELDS = %w[emergency_status emergency_contact].freeze
     inst = create(:ht_institution)
-    sign_in! username: 'admin@default.invalid'
     get edit_ht_institution_url(inst)
     EDITABLE_FIELDS.each do |ef|
       assert_match(/name="ht_institution\[#{ef}\]"/, @response.body)
@@ -186,7 +222,6 @@ class HTInstitutionsControllerEditTest < ActionDispatch::IntegrationTest
   test 'Can update emergency status' do
     new_status = '^(member)@university.invalid'
     inst = create(:ht_institution, emergency_status: nil)
-    sign_in! username: 'admin@default.invalid'
     patch ht_institution_url inst, params: {'ht_institution' => {'emergency_status' => new_status}}
 
     assert_response :redirect
@@ -201,7 +236,6 @@ class HTInstitutionsControllerEditTest < ActionDispatch::IntegrationTest
 
   test 'Blank emergency status sets null' do
     inst = create(:ht_institution, emergency_status: '^(member)@university.invalid')
-    sign_in! username: 'admin@default.invalid'
     patch ht_institution_url inst, params: {'ht_institution' => {'emergency_status' => ''}}
 
     assert_response :redirect

--- a/test/controllers/ht_users_controller_test.rb
+++ b/test/controllers/ht_users_controller_test.rb
@@ -64,6 +64,25 @@ class HTUsersControllerTest < ActionDispatch::IntegrationTest
     assert_equal '^33\.33\.33\.33$', HTUser.find(@user1.email)[:iprestrict]
   end
 
+  test 'edit user is logged' do
+    sign_in!
+    patch ht_user_url @user1, params: {'ht_user' => {'iprestrict' => '33.33.33.33'}}
+    assert_equal('33.33.33.33', @user1.ht_user_log.first.data['params']['iprestrict'])
+  end
+
+  test 'edit user does not log extraneous params' do
+    sign_in!
+    patch ht_user_url @user1, params: {'ht_user' => {'iprestrict' => '33.33.33.33',
+                                                     'nonsense' => 'should not be logged'}}
+    assert_nil(@user1.ht_user_log.first.data['params']['nonsense'])
+  end
+
+  test 'failed edit is not logged' do
+    sign_in!
+    patch ht_user_url @user1, params: {'ht_user' => {'iprestrict' => 'invalid'}}
+    assert_nil(@user1.ht_user_log.first)
+  end
+
   test 'with malformed IP address, edit IP address fails' do
     user = create(:ht_user, iprestrict: '1.2.3.4')
     sign_in!

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -29,6 +29,16 @@ FactoryBot.define do
     end
   end
 
+  factory :ht_billing_member do
+    sequence(:inst_id) { |n| "#{n}#{Faker::Internet.domain_word}" }
+
+    weight { [0.66, 1.00, 1.33].sample }
+    oclc_sym { Faker::Alphanumeric.alpha(number: 3).upcase }
+    marc21_sym { Faker::Alphanumeric.alpha(number: 4).downcase }
+    country_code { Faker::Address.country_code }
+    status { [true, false].sample }
+  end
+
   factory :ht_institution do
     sequence(:inst_id) { |n| "#{n}#{Faker::Internet.domain_word}" }
     name { Faker::University.name }

--- a/test/models/ht_billing_member_test.rb
+++ b/test/models/ht_billing_member_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+class HTBillingMemberTest < ActiveSupport::TestCase
+  test 'can persist an HTBillingMember' do
+    inst = build(:ht_billing_member)
+    inst.save
+    assert(inst.persisted?)
+  end
+
+  test 'can persist billing entity fields' do
+    inst = create(:ht_billing_member)
+    persisted = HTBillingMember.first
+
+    %i[inst_id weight oclc_sym marc21_sym country_code status].each do |field|
+      assert_equal(inst.public_send(field), persisted.public_send(field))
+    end
+  end
+
+  test 'can get the institution information' do
+    inst = create(:ht_institution)
+    billing_inst = create(:ht_billing_member, inst_id: inst.inst_id)
+
+    assert_equal(inst.name, billing_inst.ht_institution.name)
+  end
+end

--- a/test/models/ht_inst_log_test.rb
+++ b/test/models/ht_inst_log_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class HTInstitutionLogTest < ActiveSupport::TestCase
+  def setup
+    @inst = create(:ht_institution)
+    @log_data = { 'foo' => 'bar', 'baz' => 'quux' }
+    @log_entry = HTInstitutionLog.new(ht_institution: @inst, data: @log_data)
+  end
+
+  test 'can construct a log entry for a institution' do
+    assert(@log_entry)
+  end
+
+  test 'can round-trip data for a log entry' do
+    assert_equal @log_data, @log_entry.data
+  end
+
+  test 'can access persisted log data via institution' do
+    @log_entry.save
+    assert_equal @log_data, @inst.ht_institution_log.first.data
+  end
+
+  test 'is not valid without data' do
+    log_entry = HTInstitutionLog.new(ht_institution: @inst)
+    assert_not log_entry.valid?
+  end
+
+  test 'has a time by default' do
+    assert @log_entry.time
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,7 @@ def sign_in!(username: 'admin@default.invalid')
 end
 
 Keycard::DB.migrate!
+Checkpoint::DB.migrate!
 
 load File.expand_path('lib/tasks/migrate_users.rake', Rails.root)
 Rake::Task.define_task(:environment)


### PR DESCRIPTION
@mwarin Would be helpful just to verify I've done sufficient here for adding & editing the billing fields.

@moseshll `HTInstitutionsController` now handles accepting the embedded fields for the "billing member" - I don't love the way the parameter handling happens there, but I'm not sure there's really a better way. Open to suggestions.

@botimer I primarily wanted to point out the other commit to you (using MariaDB for dev & test database) to point out a couple things I'm not totally happy with with respect to keycard/checkpoint/docker -- in particular, I would prefer to use a one-shot container to run the `checkpoint:migrate`, `keycard:migrate`, `db:seed`, etc, however, if I use the pattern from https://learning.oreilly.com/library/view/docker-for-rails/9781680506730/f_0104.xhtml there doesn't seem to be a way to ensure that completes before the web container starts -- but while normal Rails apps are (normally, so far as I recall) OK if they start up before the `db:migrate` runs, with Checkpoint they check on initialization if the `grants` table is there. I suppose I could try to add a script that waits for that table to be present before starting the app, but... ugh. I suppose I could run the `db:seed` in a one-shot container and run the `checkpoint:migrate` and `keycard:migrate` every time before starting the web container, but that (conceptually) doesn't seem quite right either. Let me know if you have any thoughts out of that conundrum. Also perhaps worth thinking if you have a good pattern for orchestrating those sorts of things in Kubernetes.