### PR TITLE
db schema updates; billing member fixes

### DIFF
--- a/app/models/ht_institution.rb
+++ b/app/models/ht_institution.rb
@@ -2,7 +2,7 @@
 
 class HTInstitution < ApplicationRecord
   has_one :ht_billing_member, foreign_key: 'inst_id'
-  accepts_nested_attributes_for :ht_billing_member
+  accepts_nested_attributes_for :ht_billing_member, update_only: true
 
   self.primary_key = 'inst_id'
   has_many :ht_users, foreign_key: :identity_provider, primary_key: :entityID

--- a/app/models/ht_institution.rb
+++ b/app/models/ht_institution.rb
@@ -30,14 +30,10 @@ class HTInstitution < ApplicationRecord
   end
 
   def set_defaults
-    self.sdrinst ||= inst_id
     self.mapto_inst_id ||= inst_id
-    self.orph_agree ||= false
-
     return unless entityID
 
     self.template ||= "https://___HOST___/Shibboleth.sso/Login?entityID=#{entityID}&target=___TARGET___"
-    self.authtype ||= 'shibboleth'
   end
 
   def set_defaults_for_entity(entity_id, metadata = SAMLMetadata.new(entity_id))

--- a/app/presenters/ht_institution_presenter.rb
+++ b/app/presenters/ht_institution_presenter.rb
@@ -90,6 +90,10 @@ class HTInstitutionPresenter < SimpleDelegator
     button 'Cancel', persisted? ? ht_institution_path(inst_id) : ht_institutions_path
   end
 
+  def show_create_billing_member?
+    !persisted? || !ht_billing_member&.persisted?
+  end
+
   def form_inst_id(form)
     if persisted?
       inst_id

--- a/app/views/ht_institutions/_form.html.erb
+++ b/app/views/ht_institutions/_form.html.erb
@@ -45,7 +45,13 @@
         <%= form.select :enabled, @institution.badge_options %>
         </dd>
 
-        <%= form.fields_for :ht_billing_member do |billing_form| %>
+        <% if @institution.show_create_billing_member? %>
+          <dt>Add billing info?:</dt> <dd>
+          <%= check_box_tag :create_billing_member %>
+          </dd>
+        <% end %>
+
+        <%= form.fields_for :ht_billing_member, @institution.ht_billing_member || HTBillingMember.new do |billing_form| %>
         <dt>Weight:</dt>
         <dd><%= billing_form.text_field :weight, size:8 %>
         <dt>OCLC Symbol:</dt>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -87,6 +87,6 @@ ActiveRecord::Schema.define(version: 0) do # rubocop:disable Metrics/BlockLength
     t.string :oclc_sym
     t.string :marc21_sym
     t.string :country_code, default: 'us'
-    t.boolean :status, default: false 
+    t.boolean :status, default: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -34,21 +34,15 @@ ActiveRecord::Schema.define(version: 0) do # rubocop:disable Metrics/BlockLength
   end
 
   create_table :ht_institutions, id: false do |t|
-    t.string :sdrinst # deprecated
     t.string :inst_id, primary_key: true
     t.string :grin_instance
     t.string :name
     t.string :template
-    t.string :authtype
     t.string :domain
     t.boolean :us
-    t.string :mapto_domain
-    t.string :mapto_sdrinst
     t.string :mapto_inst_id
     t.string :mapto_name
-    t.string :mapto_entityID
     t.integer :enabled
-    t.boolean :orph_agree
     t.string :entityID
     t.text :allowed_affiliations
     t.string :shib_authncontext_class
@@ -89,11 +83,10 @@ ActiveRecord::Schema.define(version: 0) do # rubocop:disable Metrics/BlockLength
 
   create_table :ht_billing_members, id: false do |t|
     t.string :inst_id, primary_key: true
-
-    t.column :weight, :decimal, precision: 4, scale: 2
+    t.column :weight, :decimal, precision: 4, scale: 2, default: 0.00
     t.string :oclc_sym
     t.string :marc21_sym
-    t.string :country_code
-    t.boolean :status
+    t.string :country_code, default: 'us'
+    t.boolean :status, default: false 
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -77,7 +77,6 @@ def create_ht_institution(enabled) # rubocop:disable Metrics/MethodLength
   HTInstitution.create(
     inst_id: inst_id,
     name: Faker::University.name,
-    authtype: ['', 'shibboleth'].sample,
     domain: domain,
     us: [0, 1].sample,
     enabled: enabled,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -80,7 +80,6 @@ def create_ht_institution(enabled) # rubocop:disable Metrics/MethodLength
     domain: domain,
     us: [0, 1].sample,
     enabled: enabled,
-    orph_agree: [0, 1].sample,
     entityID: Faker::Internet.url,
     allowed_affiliations: '^(alum|member)' + domain,
     shib_authncontext_class: [nil, Faker::Internet.url].sample,

--- a/test/controllers/ht_institutions_controller_test.rb
+++ b/test/controllers/ht_institutions_controller_test.rb
@@ -182,7 +182,7 @@ class HTInstitutionsControllerCreateTest < ActionDispatch::IntegrationTest
     assert_select 'input[name="ht_institution[ht_billing_member_attributes][marc21_sym]"]'
   end
 
-  test 'saves marc code for new institution' do
+  test 'can create billing member and save marc code for new institution' do
     inst_params = attributes_for(:ht_institution)
     inst_id = inst_params[:inst_id]
     billing_params = attributes_for(:ht_billing_member)
@@ -196,11 +196,33 @@ class HTInstitutionsControllerCreateTest < ActionDispatch::IntegrationTest
           marc21_sym: billing_params[:marc21_sym],
           status: false
         }
-      }
+      },
+      create_billing_member: true
     }
 
     assert_redirected_to ht_institution_url(inst_id)
     assert_equal(HTInstitution.find(inst_id).ht_billing_member.marc21_sym, billing_params[:marc21_sym])
+  end
+
+  test 'by default does not create billing member' do
+    inst_params = attributes_for(:ht_institution)
+    inst_id = inst_params[:inst_id]
+
+    post ht_institutions_url, params: {
+      ht_institution: {
+        inst_id: inst_params[:inst_id],
+        name: inst_params[:name],
+        enabled: inst_params[:enabled],
+        ht_billing_member_attributes: {
+          country_code: 'us',
+          weight: 0.0,
+          status: false
+        }
+      }
+    }
+
+    assert_redirected_to ht_institution_url(inst_id)
+    assert_nil(HTInstitution.find(inst_id).ht_billing_member)
   end
 
   test 'logs creation' do
@@ -223,6 +245,12 @@ class HTInstitutionsControllerEditTest < ActionDispatch::IntegrationTest
     EDITABLE_FIELDS.each do |ef|
       assert_match(/name="ht_institution\[#{ef}\]"/, @response.body)
     end
+  end
+
+  test 'Billing member fields present for inst with no billing member' do
+    inst = create(:ht_institution, ht_billing_member: nil)
+    get edit_ht_institution_url(inst)
+    assert_match(/name="ht_institution\[ht_billing_member_attributes\]\[marc21_sym\]"/, @response.body)
   end
 
   test 'Can update emergency status' do
@@ -262,5 +290,49 @@ class HTInstitutionsControllerEditTest < ActionDispatch::IntegrationTest
 
     assert_not_nil(log.time)
     assert_equal(new_status, log.data['params']['emergency_status'])
+  end
+
+  test 'can add billing member for institution without one' do
+    inst = create(:ht_institution, ht_billing_member: nil)
+    billing_member_params = attributes_for(:ht_billing_member)
+
+    patch ht_institution_url inst, params: {
+      ht_institution: {
+        inst_id: inst.inst_id,
+        ht_billing_member_attributes: billing_member_params
+      },
+      create_billing_member: true
+    }
+
+    assert_equal billing_member_params[:marc21_sym], HTInstitution.find(inst.inst_id).ht_billing_member.marc21_sym
+  end
+
+  test 'by default does not add billing member for institution without one' do
+    inst = create(:ht_institution, ht_billing_member: nil)
+    billing_member_params = attributes_for(:ht_billing_member)
+
+    patch ht_institution_url inst, params: {
+      ht_institution: {
+        inst_id: inst.inst_id,
+        ht_billing_member_attributes: billing_member_params
+      }
+    }
+
+    assert_nil HTInstitution.find(inst.inst_id).ht_billing_member
+  end
+
+  test 'can edit billing fields' do
+    inst = create(:ht_institution)
+
+    patch ht_institution_url inst, params: {
+      ht_institution: {
+        inst_id: inst.inst_id,
+        ht_billing_member_attributes: {
+          country_code: 'xx'
+        }
+      }
+    }
+
+    assert_equal 'xx', HTInstitution.find(inst.inst_id).ht_billing_member.country_code
   end
 end

--- a/test/controllers/ht_institutions_controller_test.rb
+++ b/test/controllers/ht_institutions_controller_test.rb
@@ -79,9 +79,8 @@ class HTInstitutionsShowTest < ActionDispatch::IntegrationTest
   end
 
   test 'shows billing member info' do
-    billing_member = create(:ht_billing_member, inst_id: @inst.inst_id)
-
     get ht_institution_url @inst
+    billing_member = @inst.ht_billing_member
     assert_match(/#{billing_member.oclc_sym}/, @response.body)
     assert_match(/#{billing_member.marc21_sym}/, @response.body)
   end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -45,6 +45,8 @@ FactoryBot.define do
     entityID { Faker::Internet.url }
     enabled { [0, 1].sample }
 
+    association :ht_billing_member
+
     trait :mfa do
       shib_authncontext_class { 'https://refeds.org/profile/mfa' }
     end

--- a/test/models/ht_billing_member_test.rb
+++ b/test/models/ht_billing_member_test.rb
@@ -19,7 +19,7 @@ class HTBillingMemberTest < ActiveSupport::TestCase
 
   test 'can get the institution information' do
     inst = create(:ht_institution)
-    billing_inst = create(:ht_billing_member, inst_id: inst.inst_id)
+    billing_inst = inst.ht_billing_member
 
     assert_equal(inst.name, billing_inst.ht_institution.name)
   end

--- a/test/models/ht_institution_test.rb
+++ b/test/models/ht_institution_test.rb
@@ -43,13 +43,6 @@ class HTInstitutionTest < ActiveSupport::TestCase
     assert_not build(:ht_institution, enabled: nil).valid?
   end
 
-  test 'defaults sdrinst to inst_id' do
-    inst = build(:ht_institution, sdrinst: nil)
-    inst.save
-
-    assert_equal(inst.inst_id, inst.sdrinst)
-  end
-
   test 'defaults mapto_instid to inst_id' do
     inst = build(:ht_institution, mapto_inst_id: nil)
     inst.save
@@ -63,19 +56,5 @@ class HTInstitutionTest < ActiveSupport::TestCase
 
     assert_equal('https://___HOST___/Shibboleth.sso/Login?entityID=urn:something&target=___TARGET___',
                  inst.template)
-  end
-
-  test 'sets authtype on save if entityid is set' do
-    inst = build(:ht_institution, entityID: 'urn:something')
-    inst.save
-
-    assert_equal(inst.authtype, 'shibboleth')
-  end
-
-  test 'defaults orph_agree to false' do
-    inst = build(:ht_institution, orph_agree: nil)
-    inst.save
-
-    assert_equal(inst.orph_agree, false)
   end
 end

--- a/test/presenters/ht_institution_presenter_test.rb
+++ b/test/presenters/ht_institution_presenter_test.rb
@@ -17,6 +17,16 @@ class HTInstitutionPresenterTest < ActiveSupport::TestCase
     assert_equal('', presenter(inst).us_icon)
   end
 
+  test 'billing enabled' do
+    inst = build(:ht_institution, ht_billing_member: build(:ht_billing_member, status: true))
+    assert_match('glyphicon', presenter(inst).billing_enabled_icon)
+  end
+
+  test 'billing disabled' do
+    inst = build(:ht_institution, ht_billing_member: build(:ht_billing_member, status: false))
+    assert_match('', presenter(inst).billing_enabled_icon)
+  end
+
   test 'etas active' do
     inst = build(:ht_institution, emergency_status: '^(member)@default.invalid')
     assert_match('glyphicon', presenter(inst).etas_active_icon)


### PR DESCRIPTION
- Remove `ht_institutions` fields that are no longer present in production

- Improve behavior for billing members. The `accepts_attributes_for` stuff is kind of a mess, esp. in figuring out whether or not to add/edit something; longer term, it would probably be better to explicitly just add a form for that object rather than having it as nested attributes. I thought `accepts_attributes_for` would be easier since it's a 1:1 relationship, but in fact it creates a bit of a mess. I think if we want to make more changes to billing members it's probably worth experimenting with other options here.