### PR TITLE
Run assets:precompile at runtime after RAILS_RELATIVE_URL_ROOT is set

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,4 @@ RUN gem install bundler
 #
 # COPY . /usr/src/app
 
-CMD ["bin/rails","s","-b","0.0.0.0"]
-
-
+CMD ["sh", "-c", "bin/rails assets:precompile && bin/rails s -b 0.0.0.0"]

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -19,6 +19,5 @@ ENV RAILS_ENV production
 ENV BUNDLE_PATH /gems
 RUN bundle install
 COPY --chown=$UID:$GID . /usr/src/app
-RUN bin/rails assets:precompile SECRET_KEY_BASE=1
 
-CMD ["bin/rails", "s"]
+CMD ["sh", "-c", "bin/rails assets:precompile && bin/rails s"]


### PR DESCRIPTION
Not sure about changing the `CMD` in `Dockerfile` as opposed to `Dockerfile.prod` -- I believe it to be unused. Changing it to parallel the production file anyway.