### PR TITLE
HT-2403 'approved' renewal requests expire so they can be renewed aga…

### DIFF
--- a/app/controllers/ht_approval_requests_controller.rb
+++ b/app/controllers/ht_approval_requests_controller.rb
@@ -18,8 +18,9 @@ class HTApprovalRequestsController < ApplicationController
   end
 
   def index
-    reqs = HTApprovalRequest.order('approver')
-    @reqs = reqs.map { |r| HTApprovalRequestPresenter.new(r) }
+    requests = HTApprovalRequest.order('approver')
+    @active_reqs = requests.not_renewed.map { |r| HTApprovalRequestPresenter.new(r) }
+    @inactive_reqs = requests.renewed.map { |r| HTApprovalRequestPresenter.new(r) }
     @added_users = session[:added_users] || []
     @renewed_users = session[:renewed_users] || []
     session.delete :added_users
@@ -61,7 +62,7 @@ class HTApprovalRequestsController < ApplicationController
   end
 
   # Add an approval request for selected users.
-  # If one already exists, silently skip over it.
+  # If unrenewed one already exists, silently skip over it.
   # Returns an Array of ht_user emails added to requests.
   def add_requests(emails) # rubocop:disable Metrics/MethodLength
     if emails.nil? || emails.empty?
@@ -70,7 +71,7 @@ class HTApprovalRequestsController < ApplicationController
     end
     adds = []
     emails.each do |e|
-      next if HTApprovalRequest.where(userid: e).count.positive?
+      next if HTApprovalRequest.where(userid: e, renewed: nil).count.positive?
 
       begin
         add_request e

--- a/app/controllers/ht_approval_requests_controller.rb
+++ b/app/controllers/ht_approval_requests_controller.rb
@@ -19,8 +19,8 @@ class HTApprovalRequestsController < ApplicationController
 
   def index
     requests = HTApprovalRequest.order('approver')
-    @active_reqs = requests.not_renewed.map { |r| HTApprovalRequestPresenter.new(r) }
-    @inactive_reqs = requests.renewed.map { |r| HTApprovalRequestPresenter.new(r) }
+    @incomplete_reqs = requests.not_renewed.map { |r| HTApprovalRequestPresenter.new(r) }
+    @complete_reqs = requests.renewed.map { |r| HTApprovalRequestPresenter.new(r) }
     @added_users = session[:added_users] || []
     @renewed_users = session[:renewed_users] || []
     session.delete :added_users

--- a/app/models/ht_approval_request.rb
+++ b/app/models/ht_approval_request.rb
@@ -2,9 +2,17 @@
 
 class HTApprovalRequest < ApplicationRecord
   self.primary_key = 'id'
+  # "Active" requests that may be subject to further action
   scope :not_renewed, -> { where(renewed: nil) }
+  # "Inactive" requests that are only of historical interest
+  scope :renewed, -> { where.not(renewed: nil) }
   scope :for_approver, ->(approver) { where(approver: approver).order(:sent, :received, :renewed) }
-  scope :for_user, ->(user) { where(userid: user) }
+  # Make sure that the most recent and most "incomplete" request comes first when fetching request for user
+  # If we had created/updated timestamps we could use those.
+  for_user_order = { Arel.sql('sent IS NULL') => :desc, :sent => :desc,
+                     Arel.sql('received IS NULL') => :desc, :received => :desc,
+                     Arel.sql('renewed IS NULL') => :desc, :renewed => :desc }
+  scope :for_user, ->(user) { where(userid: user).order(for_user_order) }
   scope :not_approved, -> { where(received: nil) }
   scope :approved, -> { where.not(received: nil) }
   validates :approver, presence: true

--- a/app/models/ht_approval_request.rb
+++ b/app/models/ht_approval_request.rb
@@ -7,12 +7,13 @@ class HTApprovalRequest < ApplicationRecord
   # "Inactive" requests that are only of historical interest
   scope :renewed, -> { where.not(renewed: nil) }
   scope :for_approver, ->(approver) { where(approver: approver).order(:sent, :received, :renewed) }
+  scope :for_user, ->(user) { where(userid: user).order(:sent, :received, :renewed) }
   # Make sure that the most recent and most "incomplete" request comes first when fetching request for user
   # If we had created/updated timestamps we could use those.
-  for_user_order = { Arel.sql('sent IS NULL') => :desc, :sent => :desc,
-                     Arel.sql('received IS NULL') => :desc, :received => :desc,
-                     Arel.sql('renewed IS NULL') => :desc, :renewed => :desc }
-  scope :for_user, ->(user) { where(userid: user).order(for_user_order) }
+  most_recent_order = { Arel.sql('sent IS NULL') => :desc, :sent => :desc,
+                        Arel.sql('received IS NULL') => :desc, :received => :desc,
+                        Arel.sql('renewed IS NULL') => :desc, :renewed => :desc }
+  scope :most_recent, ->(user) { for_user(user).order(most_recent_order) }
   scope :not_approved, -> { where(received: nil) }
   scope :approved, -> { where.not(received: nil) }
   validates :approver, presence: true

--- a/app/presenters/ht_approval_request_presenter.rb
+++ b/app/presenters/ht_approval_request_presenter.rb
@@ -22,6 +22,7 @@ end
 class HTApprovalRequestPresenter < SimpleDelegator
   include ActionView::Helpers::FormTagHelper
   include Rails.application.routes.url_helpers
+
   BADGES = {
     approved: HTApprovalRequestBadge.new('approved', 'label-info'),
     expired: HTApprovalRequestBadge.new('expired', 'label-danger'),

--- a/app/presenters/ht_user_presenter.rb
+++ b/app/presenters/ht_user_presenter.rb
@@ -75,7 +75,7 @@ class HTUserPresenter < SimpleDelegator
   end
 
   def approval_request
-    @approval_request ||= HTApprovalRequest.for_user(email).first
+    @approval_request ||= HTApprovalRequest.most_recent(email).first
   end
 
   def checkmark_icon(field)

--- a/app/presenters/ht_user_presenter.rb
+++ b/app/presenters/ht_user_presenter.rb
@@ -20,7 +20,7 @@ class HTUserPresenter < SimpleDelegator
   end
 
   def can_request?
-    approval_request.nil?
+    approval_request.nil? || approval_request.renewed.present?
   end
 
   def select_for_renewal_checkbox

--- a/app/views/ht_approval_requests/index.html.erb
+++ b/app/views/ht_approval_requests/index.html.erb
@@ -7,6 +7,7 @@
   <%= render 'shared/flash_message' %>
 
   <%= form_tag(ht_approval_requests_path, method: :post) do %>
+  <h2 class="pull-left">Active Requests</h2>
   <table id="active_users" class="table table-striped" data-toggle="table" data-height="460" data-virtual-scroll="true"
          data-search="true" data-show-search-clear-button="true">
     <thead class="thead-dark">
@@ -20,8 +21,8 @@
     </tr>
     </thead>
 
-    <% @reqs.each do |req| %>
-      <tr <%= raw @added_users.include?(req.userid) || @renewed_users.include?(req.userid) ? 'class="success"' : '' %>>
+    <% @active_reqs.each do |req| %>
+      <%= tag(:tr, class: @added_users.include?(req.userid) ? :success : nil) %>
         <td>
           <% if can?(:edit, :ht_approval_requests) %>
             <%= req.select_for_renewal_checkbox %>
@@ -53,5 +54,28 @@
     <%= submit_tag 'Renew Selected Users', name: 'submit_renewals', class: 'btn btn-primary' %>
   <% end %>
   <% end # form-tag %>
+  <h2 class="pull-left">Inactive Requests</h2>
+  <table id="inactive_users" class="table table-striped" data-toggle="table" data-height="460" data-virtual-scroll="true"
+         data-search="true" data-show-search-clear-button="true">
+    <thead class="thead-dark">
+    <tr>
+      <th data-sortable="true">Approver</th>
+      <th data-sortable="true">User</th>
+      <th data-sortable="true">Sent</th>
+      <th data-sortable="true">Approved</th>
+      <th data-sortable="true">Renewed</th>
+    </tr>
+    </thead>
+
+    <% @inactive_reqs.each do |req| %>
+      <%= tag(:tr, class: @renewed_users.include?(req.userid) ? :success : nil) %>
+        <td><%= req.approver %></td>
+        <td><%= link_to req.userid, ht_user_path(req.userid) %></td>
+        <td><%= req.sent(short: true) %></td>
+        <td><%= req.received(short: true) %></td>
+        <td><%= req.renewed(short: true) %></td>
+      </tr>
+    <% end %>
+  </table>
 </div>
 

--- a/app/views/ht_approval_requests/index.html.erb
+++ b/app/views/ht_approval_requests/index.html.erb
@@ -21,7 +21,7 @@
     </tr>
     </thead>
 
-    <% @active_reqs.each do |req| %>
+    <% @incomplete_reqs.each do |req| %>
       <%= tag(:tr, class: @added_users.include?(req.userid) ? :success : nil) %>
         <td>
           <% if can?(:edit, :ht_approval_requests) %>
@@ -67,7 +67,7 @@
     </tr>
     </thead>
 
-    <% @inactive_reqs.each do |req| %>
+    <% @complete_reqs.each do |req| %>
       <%= tag(:tr, class: @renewed_users.include?(req.userid) ? :success : nil) %>
         <td><%= req.approver %></td>
         <td><%= link_to req.userid, ht_user_path(req.userid) %></td>

--- a/test/controllers/ht_approval_requests_controller_test.rb
+++ b/test/controllers/ht_approval_requests_controller_test.rb
@@ -14,7 +14,8 @@ class HTApprovalRequestControllerIndexTest < ActionDispatch::IntegrationTest
     sign_in!
     get ht_approval_requests_url
     assert_response :success
-    assert_not_nil assigns(:reqs)
+    assert_not_nil assigns(:active_reqs)
+    assert_not_nil assigns(:inactive_reqs)
     assert_equal 'index', @controller.action_name
   end
 
@@ -44,7 +45,8 @@ class HTApprovalRequestControllerIndexTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_equal 2, HTApprovalRequest.count
     assert_match 'Added', flash[:notice]
-    assert_not_nil assigns(:reqs)
+    assert_not_nil assigns(:active_reqs)
+    assert_not_nil assigns(:inactive_reqs)
     assert_equal 'index', @controller.action_name
     assert_select "a[href='#{edit_ht_approval_request_path(@user1.approver)}']"
   end
@@ -54,8 +56,8 @@ class HTApprovalRequestControllerIndexTest < ActionDispatch::IntegrationTest
     post ht_approval_requests_url, params: {submit_requests: true}
     assert_response :redirect
     follow_redirect!
-    assert_not_nil assigns(:reqs)
-    assert_empty assigns(:reqs)
+    assert_not_nil assigns(:active_reqs)
+    assert_empty assigns(:active_reqs)
     assert_match 'No users selected', flash[:alert]
     assert_equal 'index', @controller.action_name
   end
@@ -65,8 +67,8 @@ class HTApprovalRequestControllerIndexTest < ActionDispatch::IntegrationTest
     post ht_approval_requests_url, params: {ht_users: ['nobody@nowhere.org'], submit_requests: true}
     assert_response :redirect
     follow_redirect!
-    assert_not_nil assigns(:reqs)
-    assert_empty assigns(:reqs)
+    assert_not_nil assigns(:active_reqs)
+    assert_empty assigns(:active_reqs)
     assert_match "Couldn't find HTUser", flash[:alert]
     assert_equal 'index', @controller.action_name
   end

--- a/test/controllers/ht_approval_requests_controller_test.rb
+++ b/test/controllers/ht_approval_requests_controller_test.rb
@@ -14,8 +14,8 @@ class HTApprovalRequestControllerIndexTest < ActionDispatch::IntegrationTest
     sign_in!
     get ht_approval_requests_url
     assert_response :success
-    assert_not_nil assigns(:active_reqs)
-    assert_not_nil assigns(:inactive_reqs)
+    assert_not_nil assigns(:incomplete_reqs)
+    assert_not_nil assigns(:complete_reqs)
     assert_equal 'index', @controller.action_name
   end
 
@@ -45,8 +45,8 @@ class HTApprovalRequestControllerIndexTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_equal 2, HTApprovalRequest.count
     assert_match 'Added', flash[:notice]
-    assert_not_nil assigns(:active_reqs)
-    assert_not_nil assigns(:inactive_reqs)
+    assert_not_nil assigns(:incomplete_reqs)
+    assert_not_nil assigns(:complete_reqs)
     assert_equal 'index', @controller.action_name
     assert_select "a[href='#{edit_ht_approval_request_path(@user1.approver)}']"
   end
@@ -56,8 +56,8 @@ class HTApprovalRequestControllerIndexTest < ActionDispatch::IntegrationTest
     post ht_approval_requests_url, params: {submit_requests: true}
     assert_response :redirect
     follow_redirect!
-    assert_not_nil assigns(:active_reqs)
-    assert_empty assigns(:active_reqs)
+    assert_not_nil assigns(:incomplete_reqs)
+    assert_empty assigns(:incomplete_reqs)
     assert_match 'No users selected', flash[:alert]
     assert_equal 'index', @controller.action_name
   end
@@ -67,8 +67,8 @@ class HTApprovalRequestControllerIndexTest < ActionDispatch::IntegrationTest
     post ht_approval_requests_url, params: {ht_users: ['nobody@nowhere.org'], submit_requests: true}
     assert_response :redirect
     follow_redirect!
-    assert_not_nil assigns(:active_reqs)
-    assert_empty assigns(:active_reqs)
+    assert_not_nil assigns(:incomplete_reqs)
+    assert_empty assigns(:incomplete_reqs)
     assert_match "Couldn't find HTUser", flash[:alert]
     assert_equal 'index', @controller.action_name
   end

--- a/test/models/ht_approval_request_test.rb
+++ b/test/models/ht_approval_request_test.rb
@@ -52,13 +52,13 @@ class HTApprovalRequestTest < ActiveSupport::TestCase
     assert_equal req.id, req.resource_id
   end
 
-  test 'for_user finds most recent or most incomplete' do
+  test 'most_recent finds most recent or most incomplete' do
     long_ago = Faker::Time.backward
     @active_user = create(:ht_user)
     create(:ht_approval_request, ht_user: @active_user, sent: long_ago, received: long_ago, renewed: long_ago)
     create(:ht_approval_request, ht_user: @active_user, sent: long_ago, received: long_ago, renewed: long_ago)
     req = create(:ht_approval_request, ht_user: @active_user, sent: nil, token_hash: nil)
-    latest = HTApprovalRequest.for_user(@active_user).first
+    latest = HTApprovalRequest.most_recent(@active_user).first
     assert_equal(req, latest)
   end
 end

--- a/test/models/ht_approval_request_test.rb
+++ b/test/models/ht_approval_request_test.rb
@@ -45,6 +45,22 @@ class HTApprovalRequestTest < ActiveSupport::TestCase
 
     assert_equal(HTApprovalRequest.digest(token), req.token_hash)
   end
+
+  test 'has correct Checkpoint attributes' do
+    req = create(:ht_approval_request, :expired)
+    assert_equal :ht_approval_request, req.resource_type
+    assert_equal req.id, req.resource_id
+  end
+
+  test 'for_user finds most recent or most incomplete' do
+    long_ago = Faker::Time.backward
+    @active_user = create(:ht_user)
+    create(:ht_approval_request, ht_user: @active_user, sent: long_ago, received: long_ago, renewed: long_ago)
+    create(:ht_approval_request, ht_user: @active_user, sent: long_ago, received: long_ago, renewed: long_ago)
+    req = create(:ht_approval_request, ht_user: @active_user, sent: nil, token_hash: nil)
+    latest = HTApprovalRequest.for_user(@active_user).first
+    assert_equal(req, latest)
+  end
 end
 
 class HTApprovalRequestUniquenessTest < ActiveSupport::TestCase

--- a/test/presenters/ht_user_presenter_test.rb
+++ b/test/presenters/ht_user_presenter_test.rb
@@ -52,25 +52,37 @@ class HTUserPresenterTest < ActiveSupport::TestCase
     assert_match 'checkbox', user.mfa_checkbox
   end
 
-  test 'select for renewal checkbox' do
+  test 'select checkbox by default' do
     user = HTUserPresenter.new(create(:ht_user))
     assert_match('checkbox', user.select_for_renewal_checkbox)
   end
 
-  test 'no select for renewal checkbox' do
+  test 'select checkbox if request is not renewed' do
     user = HTUserPresenter.new(create(:ht_user))
-    create(:ht_approval_request, :renewed, userid: user.email)
-    assert_equal('', user.select_for_renewal_checkbox)
+    create(:ht_approval_request, renewed: nil, userid: user.email)
+    assert_no_match('checkbox', user.select_for_renewal_checkbox)
   end
 
-  test 'email link has label' do
+  test 'select checkbox if user is renewed' do
+    user = HTUserPresenter.new(create(:ht_user))
+    create(:ht_approval_request, :renewed, userid: user.email)
+    assert_match('checkbox', user.select_for_renewal_checkbox)
+  end
+
+  test 'email link has label by default' do
     user = HTUserPresenter.new(create(:ht_user))
     assert_match('label', user.email_link)
   end
 
-  test 'email link has no label' do
+  test 'email link has no label if request is not renewed' do
+    user = HTUserPresenter.new(create(:ht_user))
+    create(:ht_approval_request, renewed: nil, userid: user.email)
+    assert_no_match('label', user.email_link)
+  end
+
+  test 'email link has label if request is renewed' do
     user = HTUserPresenter.new(create(:ht_user))
     create(:ht_approval_request, :renewed, userid: user.email)
-    assert_no_match('label', user.email_link)
+    assert_match('label', user.email_link)
   end
 end


### PR DESCRIPTION
…in next year

Approach this like dividing users into active and inactive, with requests that have been renewed sequestered in a second list. A user with a renewed (the ticket says "approved" but I think that is an oversight) request should no longer be prevented from having a new approval request created.

It may be in future the inactive/renewed requests need not even be acknowledged in the UI. Let's go with this for now. I'd rather hide them than do a mass deletion.

No attempt has been made to be smart about when to allow a new request to be generated. I trust the "Expires" column will be the primary driver.

