### PR TITLE
use RAILS_LOG_LEVEL; log at INFO level by default in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,9 +49,8 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :debug
+  # Default to info when running in production mode
+  config.log_level = ENV["RAILS_LOG_LEVEL"] || :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]

--- a/kube/environments/staging/main.jsonnet
+++ b/kube/environments/staging/main.jsonnet
@@ -3,7 +3,8 @@
   _config+:: {
     otis+: {
       web+: {
-        host: 'staging.otis.kubernetes.hathitrust.org'
+        host: 'staging.otis.kubernetes.hathitrust.org',
+        log_level: 'debug'
       },
     }
   },

--- a/kube/environments/testing/main.jsonnet
+++ b/kube/environments/testing/main.jsonnet
@@ -4,6 +4,7 @@
     otis+: {
       web+: {
         host: 'testing.otis.kubernetes.hathitrust.org',
+        log_level: 'debug',
         relative_url_root: '/otis-testing'
       },
     }

--- a/kube/lib/otis/config.libsonnet
+++ b/kube/lib/otis/config.libsonnet
@@ -5,6 +5,7 @@
         name: 'web',
         port: 3000,
         host: 'otis.kubernetes.hathitrust.org',
+        log_level: 'info',
         relative_url_root: '/otis',
         app_config: {
           configmap: 'production-config',

--- a/kube/lib/otis/otis.libsonnet
+++ b/kube/lib/otis/otis.libsonnet
@@ -25,6 +25,7 @@
                    .withEnv([
                      env.fromSecretRef("RAILS_MASTER_KEY","rails-master-key","rails-master-key"),
                      env.fromSecretRef("DB_URL","db-url","db-url"),
+                     env.new("RAILS_LOG_LEVEL",config.web.log_level),
                      env.new("RAILS_RELATIVE_URL_ROOT",config.web.relative_url_root)])
                    .withVolumeMounts([
                      volumeMount.new(name=app_config.configmap,


### PR DESCRIPTION
Rails 5 defaulted to debug logging in production, but this is noisy, can leak PII, and not allowed by A&E policy.

This changes the default level to info but allows overriding it via `RAILS_LOG_LEVEL`, then sets it back to debug for testing & staging.

FYI @botimer 