### PR TITLE
HT-2452 do not re-request approval for expired users.

### DIFF
--- a/app/models/ht_user.rb
+++ b/app/models/ht_user.rb
@@ -179,6 +179,9 @@ class HTUser < ApplicationRecord
   private
 
   def clean_requests
-    ht_approval_request.not_approved.not_renewed.destroy_all if saved_change_to_approver?
+    if saved_change_to_approver? || (saved_change_to_expires? &&
+                                     expiration_date(true).days_until_expiration < 1)
+      ht_approval_request.not_approved.not_renewed.destroy_all
+    end
   end
 end

--- a/test/models/ht_user_test.rb
+++ b/test/models/ht_user_test.rb
@@ -219,3 +219,28 @@ class HTUserUpdateApprover < ActiveSupport::TestCase
     end
   end
 end
+
+class HTUserManualExpire < ActiveSupport::TestCase
+  def setup
+    @user = create(:ht_user, approver: "somebody@example.com")
+  end
+
+  test "deletes non-approved request when manually expiring user" do
+    create(:ht_approval_request, ht_user: @user, sent: Faker::Time.backward)
+    @user.reload
+    @user.expires = Time.zone.now
+    assert_difference -> { HTApprovalRequest.count }, -1 do
+      @user.save
+    end
+  end
+
+  test "does not delete approved request when manually expiring user" do
+    create(:ht_approval_request, ht_user: @user, received: Faker::Time.backward)
+
+    @user.reload
+    @user.expires = Time.zone.now
+    assert_no_difference -> { HTApprovalRequest.count } do
+      @user.save
+    end
+  end
+end


### PR DESCRIPTION
Applies only to manually-expired users, when the approval request has not been sent or responded to by approver.
Works in the same way as manual change of approver, by deleting stale approval requests.