### PR TITLE
Adds HTContact and HTContactType models.

### DIFF
--- a/app/controllers/ht_contact_types_controller.rb
+++ b/app/controllers/ht_contact_types_controller.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class HTContactTypesController < ApplicationController
+  before_action :fetch_contact_type, only: %i[destroy edit show]
+
+  PERMITTED_UPDATE_FIELDS = %i[name description].freeze
+  PERMITTED_CREATE_FIELDS = PERMITTED_UPDATE_FIELDS + %i[id]
+
+  def new
+    @contact_type = HTContactTypePresenter.new(HTContactType.new)
+  end
+
+  def index
+    contact_types = HTContactType.order(:name)
+    @contact_types = contact_types.map { |c| HTContactTypePresenter.new(c) }
+  end
+
+  def update
+    @contact_type = HTContactType.find(params[:id])
+    if @contact_type.update(contact_type_params(PERMITTED_UPDATE_FIELDS))
+      flash[:notice] = "Contact type updated"
+      redirect_to @contact_type
+    else
+      flash.now[:alert] = @contact_type.errors.full_messages.to_sentence
+      fetch_contact_type
+      render :edit
+    end
+  end
+
+  def create
+    @contact_type = HTContactType.new(contact_type_params(PERMITTED_CREATE_FIELDS))
+    if @contact_type.save
+      redirect_to @contact_type, note: "Contact type successfully created"
+    else
+      flash.now[:alert] = @contact_type.errors.full_messages.to_sentence
+      @contact_type = HTContactTypePresenter.new(@contact_type)
+      render :new
+    end
+  end
+
+  def destroy
+    if @contact_type.destroy
+      flash[:notice] = "Contact type removed"
+      redirect_to ht_contact_types_url
+    else
+      flash.now[:alert] = @contact_type.errors.full_messages.to_sentence
+      render :show
+    end
+  end
+
+  private
+
+  def contact_type_params(permitted_fields)
+    @contact_type_params ||= params.require(:ht_contact_type)
+      .permit(*permitted_fields)
+      .transform_values! { |v| v.present? ? v : nil }
+  end
+
+  def fetch_contact_type
+    @contact_type = HTContactTypePresenter.new(HTContactType.find(params[:id]))
+  end
+end

--- a/app/controllers/ht_contacts_controller.rb
+++ b/app/controllers/ht_contacts_controller.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+class HTContactsController < ApplicationController
+  before_action :fetch_contact, only: %i[destroy edit show]
+
+  PERMITTED_UPDATE_FIELDS = %i[inst_id contact_type email].freeze
+  PERMITTED_CREATE_FIELDS = PERMITTED_UPDATE_FIELDS + %i[id]
+
+  def new
+    @contact = HTContactPresenter.new(HTContact.new)
+  end
+
+  def index
+    contacts = HTContact.includes(:ht_institution).order("ht_institutions.name")
+    @contacts = contacts.map { |c| HTContactPresenter.new(c) }
+  end
+
+  def update
+    @contact = HTContact.find(params[:id])
+
+    if @contact.update(contact_params(PERMITTED_UPDATE_FIELDS))
+      log
+      flash[:notice] = "Contact updated"
+      redirect_to @contact
+    else
+      flash.now[:alert] = @contact.errors.full_messages.to_sentence
+      fetch_contact
+      render :edit
+    end
+  end
+
+  def create
+    @contact = HTContact.new(contact_params(PERMITTED_CREATE_FIELDS))
+
+    if @contact.save
+      log
+      redirect_to @contact, note: "Contact #{@contact.email} created"
+    else
+      flash.now[:alert] = @contact.errors.full_messages.to_sentence
+      @contact = HTContactPresenter.new(@contact)
+      render :new
+    end
+  end
+
+  def destroy
+    if @contact.destroy
+      flash[:notice] = "contact removed"
+      redirect_to ht_contacts_url
+    else
+      flash.now[:alert] = @contact.errors.full_messages.to_sentence
+      render :show
+    end
+  end
+
+  private
+
+  def log
+    log_action(HTInstitutionLog.new(ht_institution: @contact.institution),
+      @contact_params)
+  end
+
+  def contact_params(permitted_fields)
+    @contact_params ||= params.require(:ht_contact)
+      .permit(*permitted_fields)
+      .transform_values! { |v| v.present? ? v : nil }
+  end
+
+  def fetch_contact
+    @contact = HTContactPresenter.new(HTContact.find(params[:id]))
+  end
+end

--- a/app/controllers/ht_institutions_controller.rb
+++ b/app/controllers/ht_institutions_controller.rb
@@ -12,7 +12,6 @@ class HTInstitutionsController < ApplicationController
     allowed_affiliations
     shib_authncontext_class
     emergency_status
-    emergency_contact
     mapto_inst_id
     mapto_name
     us

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,7 +2,7 @@
 
 module ApplicationHelper
   def nav_menu
-    %w[users approval_requests institutions]
+    %w[users approval_requests institutions contacts contact_types]
       .select { |item| can?(:index, "ht_#{item}") }
       .map { |item| [item.titleize, send("ht_#{item}_path")] }
   end

--- a/app/models/ht_contact.rb
+++ b/app/models/ht_contact.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Map of institution email contact and type
+class HTContact < ApplicationRecord
+  belongs_to :ht_institution, foreign_key: :inst_id, primary_key: :inst_id, required: true
+  belongs_to :ht_contact_type, foreign_key: :contact_type, primary_key: :id, required: true
+  scope :for_institution, ->(inst_id) { where(inst_id: inst_id).order(:contact_type) }
+
+  validates :inst_id, presence: true
+  validates :contact_type, presence: true
+  validates :email, presence: true, format: {with: URI::MailTo::EMAIL_REGEXP}
+
+  # Checkpoint
+  def resource_type
+    :ht_contact
+  end
+
+  def resource_id
+    id
+  end
+
+  def institution
+    HTInstitution.find(self[:inst_id])
+  end
+end

--- a/app/models/ht_contact_type.rb
+++ b/app/models/ht_contact_type.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Name and description for type of institution contact
+class HTContactType < ApplicationRecord
+  validates :name, presence: true, uniqueness: true, allow_blank: false
+  validates :description, presence: true, allow_blank: false
+
+  before_destroy :check_contacts, prepend: true
+
+  # Checkpoint
+  def resource_type
+    :ht_contact_type
+  end
+
+  def resource_id
+    id
+  end
+
+  private
+
+  def check_contacts
+    if HTContact.where(contact_type: id).count.positive?
+      errors.add(:base, "Contact type is in use")
+      throw :abort
+    end
+  end
+end

--- a/app/models/ht_institution.rb
+++ b/app/models/ht_institution.rb
@@ -7,6 +7,7 @@ class HTInstitution < ApplicationRecord
   self.primary_key = "inst_id"
   has_many :ht_users, foreign_key: :identity_provider, primary_key: :entityID
   has_many :ht_institution_log, foreign_key: :inst_id, primary_key: :inst_id
+  has_many :ht_contacts, foreign_key: :inst_id, primary_key: :inst_id
 
   validates :inst_id, presence: true, uniqueness: true
   validates :name, presence: true

--- a/app/presenters/ht_contact_presenter.rb
+++ b/app/presenters/ht_contact_presenter.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class HTContactPresenter < SimpleDelegator
+  include ActionView::Helpers::UrlHelper
+  include Rails.application.routes.url_helpers
+
+  def init(contact, _controller)
+    @contact = contact
+  end
+
+  def inst_link
+    link_to institution_display, ht_contact_path(id)
+  end
+
+  def institution_display
+    ht_institution&.name
+  end
+
+  def contact_type_display
+    ht_contact_type&.name
+  end
+
+  def email_display
+    mailto_link email
+  end
+
+  def cancel_button
+    button "Cancel", persisted? ? ht_contact_path(id) : ht_contacts_path
+  end
+
+  private
+
+  def controller
+    # required for url helpers to work
+  end
+
+  def button(title, url)
+    link_to title, url, class: "btn btn-default"
+  end
+
+  def mailto_link(value)
+    (link_to value, "mailto:#{value}" if value) || "(None)"
+  end
+end

--- a/app/presenters/ht_contact_type_presenter.rb
+++ b/app/presenters/ht_contact_type_presenter.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class HTContactTypePresenter < SimpleDelegator
+  include ActionView::Helpers::UrlHelper
+  include Rails.application.routes.url_helpers
+
+  def init(contact_type, _controller)
+    @contact_type = contact_type
+  end
+
+  def show_link
+    link_to name, ht_contact_type_path(id)
+  end
+
+  def cancel_button
+    button "Cancel", persisted? ? ht_contact_type_path(id) : ht_contact_types_path
+  end
+
+  private
+
+  def controller
+    # required for url helpers to work
+  end
+
+  def button(title, url)
+    link_to title, url, class: "btn btn-default"
+  end
+end

--- a/app/presenters/ht_institution_presenter.rb
+++ b/app/presenters/ht_institution_presenter.rb
@@ -58,10 +58,6 @@ class HTInstitutionPresenter < SimpleDelegator
     mapto_name || "(None)"
   end
 
-  def emergency_contact_link
-    (link_to emergency_contact, "mailto:#{emergency_contact}" if emergency_contact) || "(None)"
-  end
-
   def etas_affiliations
     emergency_status || "(ETAS not enabled)"
   end
@@ -108,6 +104,10 @@ class HTInstitutionPresenter < SimpleDelegator
 
   def active_user_count
     HTUser.active.where(identity_provider: entityID).count
+  end
+
+  def contacts
+    HTContact.for_institution(id).map { |c| HTContactPresenter.new c }
   end
 
   private

--- a/app/views/ht_contact_types/_form.html.erb
+++ b/app/views/ht_contact_types/_form.html.erb
@@ -1,0 +1,20 @@
+  <h1><%= @contact_type.name %></h1>
+
+  <%= render 'shared/flash_message' %>
+
+  <%= form_with(model: @contact_type, local: true, id: 'edit_ht_contact_type_form') do |form| %>
+    <div class="col-sm-6">
+      <dl class="dl-horizontal">
+        <dt>ID:</dt> <dd><%= @contact_type.id %></dd>
+
+        <dt>Name:</dt>
+        <dd><%= form.text_field :name, size: 20 %></dd>
+
+        <dt>Description:</dt> 
+        <dd> <%= form.text_area :description, size: "80x4" %> </dd>
+      </dl>
+      <%= form.submit 'Submit Changes', class: 'btn btn-primary' %>
+      <%= @contact_type.cancel_button %>
+    </div>
+
+  <% end %>

--- a/app/views/ht_contact_types/edit.html.erb
+++ b/app/views/ht_contact_types/edit.html.erb
@@ -1,0 +1,3 @@
+<div id="maincontent" class="row">
+  <%= render 'form' %>
+</div>

--- a/app/views/ht_contact_types/index.html.erb
+++ b/app/views/ht_contact_types/index.html.erb
@@ -1,0 +1,33 @@
+<div id="maincontent" class="row">
+
+  <%= render 'shared/flash_message' %>
+
+  <h2 class="pull-left">Contact Types</h2>
+
+  <table id="active_users" class="table table-striped" data-toggle="table" data-height="460" data-virtual-scroll="true"
+         data-search="true" data-show-search-clear-button="true">
+    <thead class="thead-dark">
+    <tr>
+      <th data-sortable="true">ID</th>
+      <th data-sortable="true">Name</th>
+      <th data-sortable="true">Description</th>
+    </tr>
+    </thead>
+
+    <% @contact_types.each do |c| %>
+      <tr>
+        <td><%= c.id %></td>
+        <td><%= c.show_link %></td>
+        <td><%= c.description %></td>
+      </tr>
+    <% end %>
+  </table>
+
+  <br />
+
+  <% if can?(:create, :ht_contact_types) %>
+    <%= link_to 'Add New Contact Type', new_ht_contact_type_path, class: 'btn btn-primary' %>
+  <% end %>
+
+</div>
+

--- a/app/views/ht_contact_types/new.html.erb
+++ b/app/views/ht_contact_types/new.html.erb
@@ -1,0 +1,5 @@
+<div id="maincontent" class="row">
+  <h1>New Contact Type</h1>
+
+  <%= render 'form' %>
+</div>

--- a/app/views/ht_contact_types/show.html.erb
+++ b/app/views/ht_contact_types/show.html.erb
@@ -1,0 +1,23 @@
+<div id="maincontent" class="row">
+  <h1><%= @contact_type.name %></h1>
+
+  <%= render 'shared/flash_message' %>
+
+  <div class="col-sm-6">
+    <dl class="dl-horizontal">
+      <dt>ID:</dt> <dd><%= @contact_type.id %></dd>
+      <dt>Name:</dt> <dd> <%= @contact_type.name %> </dd>
+      <dt>Description:</dt> <dd><%= @contact_type.description %></dd>
+    </dl>
+    <br/>
+
+    <% if can?(:edit, :ht_contact_types) %>
+      <%= link_to 'Edit', edit_ht_contact_type_path, class: 'btn btn-primary' %>
+    <% end %>
+    
+    <% if can?(:destroy, :ht_contact_types) %>
+      <%= link_to 'Delete Contact Type', ht_contact_type_path, method: :delete, class: 'btn btn-primary',
+                  data: { confirm: "Please confirm deletion of contact type \"#{@contact_type.name}\"" } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/ht_contacts/_form.html.erb
+++ b/app/views/ht_contacts/_form.html.erb
@@ -1,0 +1,20 @@
+  <h1><%= @contact.email %></h1>
+
+  <%= render 'shared/flash_message' %>
+
+  <%= form_with(model: @contact, local: true, id: 'edit_ht_contact_form') do |form| %>
+    <div class="col-sm-6">
+      <dl class="dl-horizontal">
+        <dt>Institution:</dt> <dd><%= form.collection_select(:inst_id, HTInstitution.enabled.all, :inst_id, :name) %></dd>
+
+        <dt>Type:</dt> <dd><%= form.collection_select(:contact_type, HTContactType.all, :id, :name) %></dd>
+
+        <dt>Email:</dt>
+        <dd><%= form.text_field :email, size: 80 %></dd>
+      </dl>
+
+      <%= form.submit 'Submit Changes', class: 'btn btn-primary' %>
+      <%= @contact.cancel_button %>
+    </div>
+
+  <% end %>

--- a/app/views/ht_contacts/edit.html.erb
+++ b/app/views/ht_contacts/edit.html.erb
@@ -1,0 +1,3 @@
+<div id="maincontent" class="row">
+  <%= render 'form' %>
+</div>

--- a/app/views/ht_contacts/index.html.erb
+++ b/app/views/ht_contacts/index.html.erb
@@ -1,0 +1,35 @@
+<div id="maincontent" class="row">
+
+  <%= render 'shared/flash_message' %>
+
+  <h2 class="pull-left">Contacts</h2>
+
+  <table id="active_users" class="table table-striped" data-toggle="table" data-height="460" data-virtual-scroll="true"
+         data-search="true" data-show-search-clear-button="true">
+    <thead class="thead-dark">
+    <tr>
+      <th data-sortable="true">ID</th>
+      <th data-sortable="true">Institution</th>
+      <th data-sortable="true">Type</th>
+      <th data-sortable="true">Email</th>
+    </tr>
+    </thead>
+
+    <% @contacts.each do |c| %>
+      <tr>
+        <td><%= c.id %></td>
+        <td><%= c.inst_link %></td>
+        <td><%= c.contact_type_display %></td>
+        <td><%= c.email_display %></td>
+      </tr>
+    <% end %>
+  </table>
+
+  <br />
+
+  <% if can?(:create, :ht_contacts) %>
+    <%= link_to 'Add New Contact', new_ht_contact_path, class: 'btn btn-primary' %>
+  <% end %>
+
+</div>
+

--- a/app/views/ht_contacts/new.html.erb
+++ b/app/views/ht_contacts/new.html.erb
@@ -1,0 +1,5 @@
+<div id="maincontent" class="row">
+  <h1>New Contact</h1>
+
+  <%= render 'form' %>
+</div>

--- a/app/views/ht_contacts/show.html.erb
+++ b/app/views/ht_contacts/show.html.erb
@@ -1,0 +1,25 @@
+<div id="maincontent" class="row">
+  <h1><%= @contact.email %></h1>
+
+  <%= render 'shared/flash_message' %>
+
+  <div class="col-sm-6">
+    <dl class="dl-horizontal">
+      <dt>ID:</dt> <dd><%= @contact.id%></dd>
+      <dt>Institution:</dt> <dd><%= @contact.institution_display %></dd>
+      <dt>Type:</dt> <dd> <%= @contact.contact_type_display %> </dd>
+      <dt>Email:</dt> <dd><%= @contact.email_display %></dd>
+    </dl>
+
+   <br />
+
+    <% if can?(:edit, :ht_contacts) %>
+      <%= link_to 'Edit', edit_ht_contact_path, class: 'btn btn-primary' %>
+    <% end %>
+
+    <% if can?(:destroy, :ht_contacts) %>
+      <%= link_to 'Delete Contact', ht_contact_path, method: :delete, class: 'btn btn-primary',
+                  data: { confirm: "Please confirm deletion of contact \"#{@contact.email}\"" } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/ht_institutions/_form.html.erb
+++ b/app/views/ht_institutions/_form.html.erb
@@ -37,9 +37,6 @@
         <dt>Affiliations for ETAS:</dt>
         <dd><%= form.text_field :emergency_status, size: 40 %></dd>
 
-        <dt>ETAS Contact:</dt>
-        <dd><%= form.text_field :emergency_contact, size: 40 %></dd>
-
         <dt>Enabled for Login:</dt> <dd>
         <%= form.select :enabled, @institution.badge_options %>
         </dd>

--- a/app/views/ht_institutions/show.html.erb
+++ b/app/views/ht_institutions/show.html.erb
@@ -21,7 +21,6 @@
       <dt>MFA auth context:</dt> <dd> <%= @institution.shib_authncontext_class %> </dd>
       <dt>Affiliations:</dt> <dd><%= @institution.allowed_affiliations %></dd>
       <dt>Affiliations for ETAS:</dt> <dd><%= @institution.etas_affiliations %></dd>
-      <dt>ETAS Contact:</dt> <dd><%= @institution.emergency_contact_link %></dd>
       <dt>Enabled for Login:</dt> <dd><%= @institution.badge %></dd>
       <dt>Last Updated:</dt> <dd><%= @institution.last_update %></dd>
 
@@ -34,10 +33,22 @@
       <% end %>
     </dl>
     <hr/>
+    <h2>Users</h2>
     <dl class="dl-horizontal">
       <dt>Active Users:</dt> <dd><%= @institution.active_user_count %></dd>
-      <dt>All Users</dt> <dd><%= @institution.user_count %></dd>
+      <dt>All Users:</dt> <dd><%= @institution.user_count %></dd>
     </dl>
+
+    <% contacts = @institution.contacts %>
+    <% if contacts.any? %>
+      <hr/>
+      <h2>Contacts</h2>
+      <dl class="dl-horizontal">
+        <% contacts.each do |contact| %>
+          <dt><%= "#{contact.contact_type_display}:" %></dt> <dd><%= contact.email_display %></dd>
+        <% end %>
+      </dl>
+    <% end %>
 
    <br />
 

--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -22,7 +22,7 @@ Keycard.config.access = Otis.config.keycard&.access || :direct
 
 Services = Canister.new
 
-role_map = {admin: [:index, :show, :save, :edit, :new, :create, :update],
+role_map = {admin: [:create, :destroy, :edit, :index, :new, :save, :show, :update],
             view: [:index, :show]}
 
 Services.register(:checkpoint) do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,14 @@ Rails.application.routes.draw do
     resources :ht_institutions
   end
 
+  scope format: false, constraints: {id: /.+/} do
+    resources :ht_contacts
+  end
+
+  scope format: false, constraints: {id: /.+/} do
+    resources :ht_contact_types
+  end
+
   get "/login", to: "session#new", as: "login"
   post "/login", to: "session#create", as: "login_as"
   unless Rails.env.production?

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -29,6 +29,10 @@ staff:
 institution:
   - institution@default.invalid
 
+# Can administer only institution contacts
+contact:
+  - contact@default.invalid
+
 shibboleth:
   url: /useradmin/Shibboleth.sso/Login
 

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -12,6 +12,10 @@ staff:
 institution:
   - institution@default.invalid
 
+# Can administer only institution contacts
+contact:
+  - contact@default.invalid
+
 # relative_url_root doesn't work for tests
 relative_url_root: '/'
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -89,4 +89,15 @@ ActiveRecord::Schema.define(version: 0) do # rubocop:disable Metrics/BlockLength
     t.string :country_code, default: 'us'
     t.boolean :status, default: false
   end
+
+  create_table :ht_contacts do |t|
+    t.string :inst_id
+    t.integer :contact_type
+    t.string :email
+  end
+
+  create_table :ht_contact_types do |t|
+    t.string :name
+    t.text :description
+  end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -97,9 +97,30 @@ def create_ht_billing_member(inst_id)
   )
 end
 
+def create_ht_contact(inst_id)
+  HTContact.create(
+    inst_id: inst_id,
+    contact_type: HTContactType.all.sample.id,
+    email: Faker::Internet.email
+  )
+end
+
+def create_ht_contact_type
+  HTContactType.create(name: Faker::Job.position,
+                       description: Faker::Lorem.sentence(word_count: 10))
+end
+
+HTContactType.create(name: "ETAS",
+                     description: "Emergency Temporary Access Service")
+
+5.times do
+  create_ht_contact_type
+end
+
 10.times do
   inst_id = create_ht_institution(1)
   create_ht_billing_member(inst_id) if [0, 1].sample.zero?
+  create_ht_contact(inst_id) if [0, 1].sample.zero?
 end
 
 2.times do

--- a/lib/tasks/migrate_users.rake
+++ b/lib/tasks/migrate_users.rake
@@ -16,6 +16,8 @@ namespace :otis do
     admin_role = Checkpoint::Credential::Role.new(:admin)
     view_role = Checkpoint::Credential::Role.new(:view)
     res_wildcard = Checkpoint::Resource::AllOfAnyType.new
+    res_contact = Checkpoint::Resource::AllOfType.new(:ht_contacts)
+    res_contact_type = Checkpoint::Resource::AllOfType.new(:ht_contact_types)
     if Otis.config.users.present?
       Otis.config.users.each do |u|
         agent = Checkpoint::Agent::Token.new("user", u)
@@ -38,6 +40,26 @@ namespace :otis do
         agent = Checkpoint::Agent::Token.new("user", u)
         unless Services.checkpoint.permits?(agent, view_role, res_inst)
           Services.checkpoint.grant!(agent, view_role, res_inst)
+        end
+        unless Services.checkpoint.permits?(agent, view_role, res_contact)
+          Services.checkpoint.grant!(agent, view_role, res_contact)
+        end
+        unless Services.checkpoint.permits?(agent, view_role, res_contact_type)
+          Services.checkpoint.grant!(agent, view_role, res_contact_type)
+        end
+      end
+    end
+    if Otis.config.contact.present?
+      Otis.config.contact.each do |u|
+        agent = Checkpoint::Agent::Token.new("user", u)
+        unless Services.checkpoint.permits?(agent, view_role, res_wildcard)
+          Services.checkpoint.grant!(agent, view_role, res_wildcard)
+        end
+        unless Services.checkpoint.permits?(agent, admin_role, res_contact)
+          Services.checkpoint.grant!(agent, admin_role, res_contact)
+        end
+        unless Services.checkpoint.permits?(agent, admin_role, res_contact_type)
+          Services.checkpoint.grant!(agent, admin_role, res_contact_type)
         end
       end
     end

--- a/test/controllers/ht_contact_types_controller_test.rb
+++ b/test/controllers/ht_contact_types_controller_test.rb
@@ -1,0 +1,250 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "w3c_validators"
+
+class HTContactTypesIndexTest < ActionDispatch::IntegrationTest
+  def setup
+    @type1 = create(:ht_contact_type, name: "AAA Type")
+    @type2 = create(:ht_contact_type, name: "ZZZ Type")
+  end
+
+  test "should get index" do
+    sign_in!
+    get ht_contact_types_url
+    assert_response :success
+    assert_not_nil assigns(:contact_types)
+    assert_equal "index", @controller.action_name
+    assert_match "Contact Types", @response.body
+    assert_match @type1.name, @response.body
+    assert_match @type2.name, @response.body
+  end
+
+  test "index is well-formed HTML" do
+    sign_in!
+    get ht_contact_types_url
+    validator = W3CValidators::NuValidator.new
+    w3c_errs = validator.validate_text(@response.body).errors
+    sleep 1
+    assert_equal 0, w3c_errs.length, w3c_errs.join("\n")
+  end
+
+  test "contact types sorted by name" do
+    sign_in!
+    get ht_contact_types_url
+
+    assert_match(/AAA.*ZZZ/m, @response.body)
+  end
+
+  test "as admin, shows link for new contact type" do
+    sign_in! username: "admin@default.invalid"
+    get ht_contact_types_url
+    assert_match "contact_types/new", @response.body
+  end
+end
+
+class HTContactTypesShowTest < ActionDispatch::IntegrationTest
+  def setup
+    @type = create(:ht_contact_type, name: "Some Type")
+    sign_in!
+  end
+
+  test "should get show page" do
+    get ht_contact_type_url @type
+    assert_response :success
+    assert_not_nil assigns(:contact_type)
+    assert_equal "show", @controller.action_name
+  end
+
+  test "show page is well-formed HTML" do
+    get ht_contact_type_url @type
+    validator = W3CValidators::NuValidator.new
+    w3c_errs = validator.validate_text(@response.body).errors
+    sleep 1
+    assert_equal 0, w3c_errs.length, w3c_errs.join("\n")
+  end
+
+  test "shows id, name, and description" do
+    get ht_contact_type_url @type
+    assert_match ERB::Util.html_escape(@type.id), @response.body
+    assert_match ERB::Util.html_escape(@type.name), @response.body
+    assert_match ERB::Util.html_escape(@type.description), @response.body
+  end
+end
+
+class HTContactTypesControllerRolesTest < ActionDispatch::IntegrationTest
+  def setup
+    @type = create(:ht_contact_type, name: "Some Type")
+  end
+
+  test "Staff user can see ht_contact_types index and show page" do
+    sign_in! username: "staff@default.invalid"
+    get ht_contact_types_url
+    assert_response :success
+    ht_contact_types_url @type
+    assert_response :success
+  end
+
+  test "Institutions-only user can see ht_contact_types index and show page" do
+    sign_in! username: "institution@default.invalid"
+    get ht_contact_types_url
+    assert_response :success
+    ht_contact_types_url @type
+    assert_response :success
+  end
+
+  test "Admin user can get edit page" do
+    sign_in! username: "admin@default.invalid"
+    get edit_ht_contact_type_url @type
+    assert_response :success
+    assert_equal "edit", @controller.action_name
+  end
+
+  test "Admin user can create new" do
+    sign_in! username: "admin@default.invalid"
+    get new_ht_contact_type_url
+    assert_response :success
+    assert_equal "new", @controller.action_name
+  end
+
+  test "Staff user cannot create new" do
+    sign_in! username: "staff@default.invalid"
+    get new_ht_contact_type_url
+    assert_response :forbidden
+  end
+
+  test "Staff user cannot edit" do
+    sign_in! username: "staff@default.invalid"
+    get edit_ht_contact_type_url @type
+    assert_response :forbidden
+  end
+
+  test "Staff user cannot update" do
+    type = create(:ht_contact_type, name: "Something")
+    sign_in! username: "staff@default.invalid"
+    patch ht_contact_type_url type, params: {ht_contact_type: {"name" => "Nothing"}}
+    assert_response :forbidden
+
+    type.reload
+    refute_equal "Nothing", HTContactType.find(type.id).name
+  end
+
+  test "Staff user cannot create" do
+    contact_type_params = attributes_for(:ht_contact_type)
+    sign_in! username: "staff@default.invalid"
+    post ht_contact_types_url, params: {ht_contact_type: contact_type_params}
+
+    assert_response :forbidden
+  end
+end
+
+class HTContactTypesControllerCreateTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in! username: "admin@default.invalid"
+  end
+
+  test "name and description editable for new contact type" do
+    get new_ht_contact_type_url
+    assert_select 'input[name="ht_contact_type[name]"]'
+    assert_select 'textarea[name="ht_contact_type[description]"]'
+  end
+
+  test "Can create" do
+    type_params = attributes_for(:ht_contact_type)
+    type_id = type_params[:id]
+    post ht_contact_types_url, params: {ht_contact_type: type_params}
+
+    assert_redirected_to ht_contact_type_url(type_id)
+    assert_not_nil(HTContactType.find(type_id))
+  end
+end
+
+class HTContactTypesControllerEditTest < ActionDispatch::IntegrationTest
+  setup do
+    @type = create(:ht_contact_type)
+    sign_in! username: "admin@default.invalid"
+  end
+
+  test "edit page is well-formed HTML" do
+    get edit_ht_contact_type_url @type
+    validator = W3CValidators::NuValidator.new
+    w3c_errs = validator.validate_text(@response.body).errors
+    sleep 1
+    assert_equal 0, w3c_errs.length, w3c_errs.join("\n")
+  end
+
+  test "Editable name and description fields present" do
+    get edit_ht_contact_type_url(@type)
+    editable_fields = %w[name description]
+    editable_fields.each do |field|
+      assert_match(/name="ht_contact_type\[#{field}\]"/, @response.body)
+    end
+  end
+
+  test "Can update name" do
+    name = "BLAH"
+    patch ht_contact_type_url @type, params: {ht_contact_type: {"name" => name}}
+
+    assert_response :redirect
+    assert_equal "update", @controller.action_name
+    assert_not_empty flash[:notice]
+    assert_redirected_to ht_contact_type_path(@type)
+    follow_redirect!
+
+    assert_match name, @response.body
+    assert_equal name, HTContactType.find(@type.id).name
+  end
+
+  test "Can update description" do
+    desc = "Blah blah blah"
+    patch ht_contact_type_url @type, params: {ht_contact_type: {"description" => desc}}
+
+    assert_response :redirect
+    assert_equal "update", @controller.action_name
+    assert_not_empty flash[:notice]
+    assert_redirected_to ht_contact_type_path(@type)
+    follow_redirect!
+
+    assert_match desc, @response.body
+    assert_equal desc, HTContactType.find(@type.id).description
+  end
+
+  test "fails update with blank field" do
+    patch ht_contact_type_url @type, params: {ht_contact_type: {"name" => ""}}
+
+    assert_response :success
+    assert_equal "update", @controller.action_name
+    assert_not_empty flash[:alert]
+  end
+end
+
+class HTContactTypesControllerDeleteTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in! username: "admin@default.invalid"
+  end
+
+  test "delete destroys the contact type" do
+    @type = create(:ht_contact_type)
+    type_id = @type.id
+    delete ht_contact_type_url @type
+    assert_response :redirect
+    assert_equal "destroy", @controller.action_name
+    assert_not_empty flash[:notice]
+    assert_redirected_to ht_contact_types_path
+    follow_redirect!
+    assert_raises ActiveRecord::RecordNotFound do
+      HTContactType.find type_id
+    end
+  end
+
+  test "destroy fails when type is in use by contact" do
+    @type = create(:ht_contact_type)
+    type_id = @type.id
+    @contact = create(:ht_contact, contact_type: @type.id)
+    delete ht_contact_type_url @type
+    assert_response :success
+    assert_equal "destroy", @controller.action_name
+    assert_not_empty flash[:alert]
+    assert_not_nil HTContactType.find type_id
+  end
+end

--- a/test/controllers/ht_contacts_controller_test.rb
+++ b/test/controllers/ht_contacts_controller_test.rb
@@ -1,0 +1,275 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "w3c_validators"
+
+class HTContactsControllerIndexTest < ActionDispatch::IntegrationTest
+  def setup
+    @inst = create(:ht_institution)
+    @contact = create(:ht_contact, inst_id: @inst.inst_id)
+  end
+
+  test "should get index" do
+    sign_in!
+    get ht_contacts_url
+    assert_response :success
+    assert_not_nil assigns(:contacts)
+    assert_equal "index", @controller.action_name
+    assert_match "Contacts", @response.body
+    assert_match @contact.email, @response.body
+  end
+
+  test "index is well-formed HTML" do
+    sign_in!
+    get ht_institutions_url
+    validator = W3CValidators::NuValidator.new
+    w3c_errs = validator.validate_text(@response.body).errors
+    sleep 1
+    assert_equal 0, w3c_errs.length, w3c_errs.join("\n")
+  end
+
+  test "contacts sorted by institution name" do
+    inst1 = create(:ht_institution, name: "AAA University", enabled: true)
+    inst2 = create(:ht_institution, name: "ZZZ University", enabled: true)
+    create(:ht_contact, inst_id: inst1.inst_id)
+    create(:ht_contact, inst_id: inst2.inst_id)
+    sign_in!
+    get ht_institutions_url
+
+    assert_match(/AAA.*ZZZ/m, @response.body)
+  end
+
+  test "as admin, shows link for new contact" do
+    sign_in! username: "admin@default.invalid"
+    get ht_contacts_url
+    assert_match "contacts/new", @response.body
+  end
+
+  test "as non-admin, shows link for new contact" do
+    sign_in! username: "staff@default.invalid"
+    get ht_contacts_url
+    assert_no_match "contacts/new", @response.body
+  end
+end
+
+class HTContactsControllerShowTest < ActionDispatch::IntegrationTest
+  def setup
+    @inst = create(:ht_institution)
+    @type = create(:ht_contact_type)
+    @contact = create(:ht_contact, ht_institution: @inst, ht_contact_type: @type)
+    sign_in!
+  end
+
+  test "should get show page" do
+    get ht_contact_url @contact
+    assert_response :success
+    assert_not_nil assigns(:contact)
+    assert_equal "show", @controller.action_name
+  end
+
+  test "show page is well-formed HTML" do
+    get ht_contact_url @contact
+    validator = W3CValidators::NuValidator.new
+    w3c_errs = validator.validate_text(@response.body).errors
+    sleep 1
+    assert_equal 0, w3c_errs.length, w3c_errs.join("\n")
+  end
+
+  test "shows contact institution name, type, email" do
+    get ht_contact_url @contact
+    assert_match ERB::Util.html_escape(@contact.institution.name), @response.body
+    assert_match ERB::Util.html_escape(@contact.ht_contact_type.name), @response.body
+    assert_match ERB::Util.html_escape(@contact.email), @response.body
+  end
+end
+
+class HTContactsControllerRolesTest < ActionDispatch::IntegrationTest
+  def setup
+    @inst = create(:ht_institution)
+    @contact = create(:ht_contact, ht_institution: @inst)
+  end
+
+  test "Staff user can see ht_contacts index and show page" do
+    sign_in! username: "staff@default.invalid"
+    get ht_contacts_url
+    assert_response :success
+    ht_contact_url @contact
+    assert_response :success
+  end
+
+  test "Institutions-only user can see ht_contacts index and show page" do
+    sign_in! username: "institution@default.invalid"
+    get ht_contacts_url
+    assert_response :success
+    ht_contact_url @contact
+    assert_response :success
+  end
+
+  test "Admin user can get edit page" do
+    sign_in! username: "admin@default.invalid"
+    get edit_ht_contact_url @contact
+    assert_response :success
+    assert_equal "edit", @controller.action_name
+  end
+
+  test "Admin user can create new" do
+    sign_in! username: "admin@default.invalid"
+    get new_ht_contact_url
+    assert_response :success
+    assert_equal "new", @controller.action_name
+  end
+
+  test "Staff user cannot create new" do
+    sign_in! username: "staff@default.invalid"
+    get new_ht_contact_url
+    assert_response :forbidden
+  end
+
+  test "Staff user cannot edit" do
+    sign_in! username: "staff@default.invalid"
+    get edit_ht_contact_url @contact
+    assert_response :forbidden
+  end
+
+  test "Staff user cannot update" do
+    contact = create(:ht_contact, inst_id: @inst.inst_id, email: "something@here.org")
+    sign_in! username: "staff@default.invalid"
+    patch ht_contact_url @contact, params: {"ht_contact" => {"email" => "nothing@there.org"}}
+    assert_response :forbidden
+
+    @contact.reload
+    refute_equal HTContact.find(contact.id).email, "nothing@there.org"
+  end
+
+  test "Staff user cannot create" do
+    contact_params = attributes_for(:ht_contact)
+    sign_in! username: "staff@default.invalid"
+    post ht_contacts_url, params: {ht_contact: contact_params}
+
+    assert_response :forbidden
+  end
+
+  test "Contact user can get edit page" do
+    sign_in! username: "contact@default.invalid"
+    get edit_ht_contact_url @contact
+    assert_response :success
+    assert_equal "edit", @controller.action_name
+  end
+
+  test "Contact user can create new" do
+    sign_in! username: "contact@default.invalid"
+    get new_ht_contact_url
+    assert_response :success
+    assert_equal "new", @controller.action_name
+  end
+end
+
+class HTContactsControllerCreateTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in! username: "admin@default.invalid"
+  end
+
+  test "inst id and contact type editable for new contact" do
+    get new_ht_contact_url
+    assert_select 'select[name="ht_contact[inst_id]"]'
+    assert_select 'select[name="ht_contact[contact_type]"]'
+  end
+
+  test "can create" do
+    contact_params = FactoryBot.build(:ht_contact).attributes.except("created_at", "updated_at").symbolize_keys
+    contact_id = contact_params[:id]
+    post ht_contacts_url, params: {ht_contact: contact_params}
+
+    assert_redirected_to ht_contact_url(contact_id)
+
+    assert_not_nil(HTContact.find(contact_id))
+  end
+
+  test "logs create" do
+    contact_params = FactoryBot.build(:ht_contact).attributes.except("created_at", "updated_at").symbolize_keys
+    contact_id = contact_params[:id]
+    post ht_contacts_url, params: {ht_contact: contact_params}
+    log = HTInstitution.find(contact_params[:inst_id]).ht_institution_log.first
+    assert_equal(contact_id.to_s, log.data["params"]["id"])
+    assert_not_nil(log.time)
+  end
+end
+
+class HTContactsControllerEditTest < ActionDispatch::IntegrationTest
+  setup do
+    @type = create(:ht_contact_type)
+    @inst = create(:ht_institution)
+    @contact = create(:ht_contact, ht_institution: @inst)
+    sign_in! username: "admin@default.invalid"
+  end
+
+  test "edit page is well-formed HTML" do
+    get edit_ht_contact_url @contact
+    validator = W3CValidators::NuValidator.new
+    w3c_errs = validator.validate_text(@response.body).errors
+    sleep 1
+    assert_equal 0, w3c_errs.length, w3c_errs.join("\n")
+  end
+
+  test "Institution and type menus present" do
+    get edit_ht_contact_url @contact
+    assert_select 'select[name="ht_contact[inst_id]"]'
+    assert_select 'select[name="ht_contact[contact_type]"]'
+  end
+
+  test "Can update institution" do
+    other_inst = create(:ht_institution, inst_id: "other_inst")
+    patch ht_contact_url @contact, params: {ht_contact: {"inst_id" => "other_inst"}}
+
+    assert_response :redirect
+    assert_equal "update", @controller.action_name
+    assert_not_empty flash[:notice]
+    assert_redirected_to ht_contact_path(@contact)
+    follow_redirect!
+
+    assert_match other_inst.name, @response.body
+    assert_equal other_inst.inst_id, HTContact.find(@contact.id).inst_id
+  end
+
+  test "Can update contact type" do
+    other_type = create(:ht_contact_type)
+    patch ht_contact_url @contact, params: {ht_contact: {"contact_type" => other_type.id}}
+
+    assert_response :redirect
+    assert_equal "update", @controller.action_name
+    assert_not_empty flash[:notice]
+    assert_redirected_to ht_contact_path(@contact)
+    follow_redirect!
+
+    assert_match other_type.name, @response.body
+    assert_equal other_type.id, HTContact.find(@contact.id).contact_type.to_i
+  end
+
+  test "fails update with bogus email" do
+    patch ht_contact_url @contact, params: {ht_contact: {"email" => "bogus_email"}}
+
+    assert_response :success
+    assert_equal "update", @controller.action_name
+    assert_not_empty flash[:alert]
+  end
+end
+
+class HTContactsControllerDeleteTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in! username: "admin@default.invalid"
+  end
+
+  test "delete destroys the contact" do
+    @contact = create(:ht_contact)
+    contact_id = @contact.id
+    delete ht_contact_url @contact
+    assert_response :redirect
+    assert_equal "destroy", @controller.action_name
+    assert_not_empty flash[:notice]
+    assert_redirected_to ht_contacts_path
+    follow_redirect!
+    assert_raises ActiveRecord::RecordNotFound do
+      HTContact.find contact_id
+    end
+  end
+end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -107,4 +107,17 @@ FactoryBot.define do
       sent { nil }
     end
   end
+
+  factory :ht_contact_type do
+    sequence(:id) { |n| n.to_s }
+    name { Faker::Lorem.unique.characters(number: 10) }
+    description { Faker::Lorem.sentence(word_count: 10) }
+  end
+
+  factory :ht_contact do
+    sequence(:id) { |n| n.to_s }
+    email { Faker::Internet.email }
+    association :ht_institution, strategy: :create
+    association :ht_contact_type, strategy: :create
+  end
 end

--- a/test/models/ht_contact_test.rb
+++ b/test/models/ht_contact_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class HTContactTest < ActiveSupport::TestCase
+  def setup
+    @type = create(:ht_contact_type)
+    @inst = create(:ht_institution)
+    @contact = create(:ht_contact, contact_type: @type.id, inst_id: @inst.inst_id)
+  end
+
+  test "validation fails without institution" do
+    assert_not build(:ht_contact, inst_id: nil).valid?
+  end
+
+  test "validation fails without type" do
+    assert_not build(:ht_contact, contact_type: nil).valid?
+  end
+
+  test "validation fails without email" do
+    assert_not build(:ht_contact, email: nil).valid?
+  end
+
+  test "validation passes" do
+    assert build(:ht_contact, email: "me@here.org").valid?
+  end
+
+  test "validation fails with invalid email" do
+    assert_not build(:ht_contact, inst_id: @inst.inst_id, contact_type: @type.id,
+                                  email: "me#here.org").valid?
+  end
+
+  test "correct Checkpoint resource_type and resource_id" do
+    assert_equal :ht_contact, @contact.resource_type
+    assert_equal @contact.id, @contact.resource_id
+  end
+end

--- a/test/models/ht_contact_type_test.rb
+++ b/test/models/ht_contact_type_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class HTContactTypeTest < ActiveSupport::TestCase
+  test "validation fails without name and description" do
+    assert_not HTContactType.new.valid?
+  end
+
+  test "validation passes" do
+    assert build(:ht_contact_type, name: "Something", description: "Something").valid?
+  end
+
+  test "name must be unique" do
+    existing_type = create(:ht_contact_type)
+    assert_not build(:ht_contact_type, name: existing_type.name, description: "Something").valid?
+  end
+
+  test "name must be not be blank" do
+    assert_not build(:ht_contact_type, name: "", description: "Something").valid?
+  end
+
+  test "description must not be blank" do
+    assert_not build(:ht_contact_type, name: "Something", description: "").valid?
+  end
+
+  test "correct Checkpoint resource_type and resource_id" do
+    type = build(:ht_contact_type, name: "Something", description: "Something")
+    assert_equal :ht_contact_type, type.resource_type
+    assert_equal type.id, type.resource_id
+  end
+end

--- a/test/models/ht_institution_test.rb
+++ b/test/models/ht_institution_test.rb
@@ -22,8 +22,8 @@ class HTInstitutionTest < ActiveSupport::TestCase
 
   test "correct Checkpoint resource_type and resource_id" do
     inst = build(:ht_institution, id: "id")
-    assert_equal inst.resource_type, :ht_institution
-    assert_equal inst.resource_id, "id"
+    assert_equal :ht_institution, inst.resource_type
+    assert_equal "id", inst.resource_id
   end
 
   test "must have an inst id" do

--- a/test/presenters/ht_contact_presenter_test.rb
+++ b/test/presenters/ht_contact_presenter_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class HTContactPresenterTest < ActiveSupport::TestCase
+  def setup
+    @type = create(:ht_contact_type)
+    @inst = create(:ht_institution)
+    @contact = HTContactPresenter.new(create(:ht_contact, ht_institution: @inst, ht_contact_type: @type))
+  end
+
+  test "#inst_link" do
+    assert_not_nil @contact.inst_link
+    assert_match "/ht_contacts/#{@contact.id}", @contact.inst_link
+  end
+
+  test "#institution_display" do
+    assert_not_nil @contact.institution_display
+    assert_match @inst.name, @contact.institution_display
+  end
+
+  test "#contact_type_display" do
+    assert_not_nil @contact.contact_type_display
+    assert_match @type.name, @contact.contact_type_display
+  end
+
+  test "#email_display" do
+    assert_not_nil @contact.email_display
+    assert_match "mailto", @contact.email_display
+  end
+
+  test "#cancel_button for saved object goes to object" do
+    assert_not_nil @contact.cancel_button
+    assert_match "/ht_contacts/#{@contact.id}", @contact.cancel_button
+  end
+
+  test "#cancel_button for unsaved object goes to index" do
+    contact = HTContactPresenter.new(build(:ht_contact))
+    assert_not_nil contact.cancel_button
+    assert_no_match "/ht_contacts/#{contact.id}", contact.cancel_button
+  end
+end

--- a/test/presenters/ht_contact_type_presenter_test.rb
+++ b/test/presenters/ht_contact_type_presenter_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class HTContactTypePresenterTest < ActiveSupport::TestCase
+  test "#show_link" do
+    type = HTContactTypePresenter.new(create(:ht_contact_type))
+    assert_not_nil type.show_link
+    assert_match "/ht_contact_types/#{type.id}", type.show_link
+  end
+
+  test "#cancel_button for unsaved object goes to index" do
+    type = HTContactTypePresenter.new(build(:ht_contact_type))
+    assert_not_nil type.cancel_button
+    assert_no_match "/ht_contact_types/#{type.id}", type.cancel_button
+  end
+
+  test "#cancel_button for saved object goes to object" do
+    type = HTContactTypePresenter.new(create(:ht_contact_type))
+    assert_not_nil type.cancel_button
+    assert_match "/ht_contact_types/#{type.id}", type.cancel_button
+  end
+end

--- a/test/presenters/ht_institution_presenter_test.rb
+++ b/test/presenters/ht_institution_presenter_test.rb
@@ -39,11 +39,6 @@ class HTInstitutionPresenterTest < ActiveSupport::TestCase
     assert_match("not enabled", presenter(inst).etas_affiliations)
   end
 
-  test "emergency contact link" do
-    inst = build(:ht_institution, emergency_contact: "somebody@default.invalid")
-    assert_match('a href="mailto:somebody@default.invalid"', presenter(inst).emergency_contact_link)
-  end
-
   test "login link" do
     inst = build(:ht_institution, entityID: "urn:something")
     assert_match(%r{Shibboleth.sso/Login.*entityID=urn:something}, presenter(inst).login_test_link)


### PR DESCRIPTION
- Adds creation, editing, deletion to users with write access to the two tables.
- Removes direct support for ETAS contact as ht_institution field.
- Adds 'contact' user role.

Caveats:
- I had to hack around a lot with FactoryBot ht_contact factory and I don't think it is very nice.
- ~~db-image needs to be updated once the proposed schema is finalized.~~