### PR TITLE
HT-3129 view and download contacts by type

### DIFF
--- a/app/views/ht_contacts/index.html.erb
+++ b/app/views/ht_contacts/index.html.erb
@@ -2,7 +2,19 @@
 
   <%= render 'shared/flash_message' %>
 
-  <h2 class="pull-left">Contacts</h2>
+  <div class="row">
+    <h2>Contacts</h2>
+  </div>
+
+  <div class="row">
+    <%= form_tag(ht_contacts_url, method: :get) do %>
+      <%= select_tag :contact_type,
+                     options_from_collection_for_select(HTContactType.all, :id, :name,
+                                                        params[:contact_type].blank? ? nil : params[:contact_type]),
+                     include_blank: "(All)" %>
+      <%= submit_tag 'Search', name: nil %>
+    <% end %>
+  </div>
 
   <table id="active_users" class="table table-striped" data-toggle="table" data-height="460" data-virtual-scroll="true"
          data-search="true" data-show-search-clear-button="true">
@@ -29,6 +41,11 @@
 
   <% if can?(:create, :ht_contacts) %>
     <%= link_to 'Add New Contact', new_ht_contact_path, class: 'btn btn-primary' %>
+  <% end %>
+  <% if @contacts.any? %>
+    <%= link_to 'Download CSV',
+                ht_contacts_url(format: :csv, contact_type: params[:contact_type]),
+                class: 'btn btn-info' %>
   <% end %>
 
 </div>


### PR DESCRIPTION
- Contacts index page can restrict to type via a dropdown menu.
- Add download CSV button.