### PR TITLE
HT-3159 purge request expired labels

### DIFF
--- a/app/controllers/ht_approval_requests_controller.rb
+++ b/app/controllers/ht_approval_requests_controller.rb
@@ -14,6 +14,10 @@ class HTApprovalRequestsController < ApplicationController
       flash[:notice] = "Renewed #{@renewed_users.join ", "}" if @renewed_users.count.positive?
       session[:renewed_users] = @renewed_users
     end
+    if params[:delete_expired]
+      deleted = delete_expired
+      flash[:notice] = "Removed #{deleted} #{"request".pluralize(deleted)}"
+    end
     redirect_to action: :index
   end
 
@@ -101,5 +105,9 @@ class HTApprovalRequestsController < ApplicationController
       flash[:alert] = e.message
     end
     adds
+  end
+
+  def delete_expired
+    HTApprovalRequest.expired.destroy_all.count
   end
 end

--- a/app/presenters/ht_approval_request_presenter.rb
+++ b/app/presenters/ht_approval_request_presenter.rb
@@ -30,6 +30,11 @@ class HTApprovalRequestPresenter < SimpleDelegator
     unsent: HTApprovalRequestBadge.new("unsent", "label-warning")
   }.freeze
 
+  def self.expired_requests
+    expired = HTApprovalRequest.expired
+    "#{expired.count} expired #{"request".pluralize(expired.count)}"
+  end
+
   def init(request)
     @request = request
   end

--- a/app/views/ht_approval_requests/index.html.erb
+++ b/app/views/ht_approval_requests/index.html.erb
@@ -53,6 +53,10 @@
   <% if can?(:edit, :ht_users) %>
     <%= submit_tag 'Renew Selected Users', name: 'submit_renewals', class: 'btn btn-primary' %>
   <% end %>
+  <% if can?(:destroy, :ht_approval_requests) && HTApprovalRequest.expired.any? %>
+    <%= submit_tag 'Delete Expired Requests', name: 'delete_expired', class: 'btn btn-danger',
+                   data: { confirm: "Please confirm deletion of #{HTApprovalRequestPresenter.expired_requests}." } %>
+  <% end %>
   <% end # form-tag %>
   <h2 class="pull-left">Inactive Requests</h2>
   <table id="inactive_users" class="table table-striped" data-toggle="table" data-height="460" data-virtual-scroll="true"

--- a/app/views/ht_contact_types/show.html.erb
+++ b/app/views/ht_contact_types/show.html.erb
@@ -16,7 +16,7 @@
     <% end %>
     
     <% if can?(:destroy, :ht_contact_types) %>
-      <%= link_to 'Delete Contact Type', ht_contact_type_path, method: :delete, class: 'btn btn-primary',
+      <%= link_to 'Delete Contact Type', ht_contact_type_path, method: :delete, class: 'btn btn-danger',
                   data: { confirm: "Please confirm deletion of contact type \"#{@contact_type.name}\"" } %>
     <% end %>
   </div>

--- a/app/views/ht_contacts/show.html.erb
+++ b/app/views/ht_contacts/show.html.erb
@@ -18,7 +18,7 @@
     <% end %>
 
     <% if can?(:destroy, :ht_contacts) %>
-      <%= link_to 'Delete Contact', ht_contact_path, method: :delete, class: 'btn btn-primary',
+      <%= link_to 'Delete Contact', ht_contact_path, method: :delete, class: 'btn btn-danger',
                   data: { confirm: "Please confirm deletion of contact \"#{@contact.email}\"" } %>
     <% end %>
   </div>

--- a/test/controllers/ht_contacts_controller_test.rb
+++ b/test/controllers/ht_contacts_controller_test.rb
@@ -276,7 +276,7 @@ class HTContactsControllerEditTest < ActionDispatch::IntegrationTest
     assert_redirected_to ht_contact_path(@contact)
     follow_redirect!
 
-    assert_match other_inst.name, @response.body
+    assert_match CGI.escapeHTML(other_inst.name), @response.body
     assert_equal other_inst.inst_id, HTContact.find(@contact.id).inst_id
   end
 


### PR DESCRIPTION
Also change "delete" buttons for contacts and contact types to a "danger" style for consistency with the purge button added to the approval requests index.

There's also a fix for one of the HTInstitution tests that wasn't HTML-escaping the institution name. There are likely others. (Culprit was an unescaped apostrophe.)