### PR TITLE
HT-3054 users with admin ht_users can't admin approval requests

### DIFF
--- a/app/lib/otis/authorization/resource.rb
+++ b/app/lib/otis/authorization/resource.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Otis
+  module Authorization
+    module Resource
+      def self.included(klass)
+        klass.extend ClassMethods
+      end
+
+      module ClassMethods
+        def to_resource
+          Checkpoint::Resource::AllOfType.new to_s.underscore.to_sym
+        end
+
+        def to_resource_name
+          to_s.underscore.to_sym
+        end
+      end
+
+      def to_resource
+        Checkpoint::Resource.new self
+      end
+
+      def resource_type
+        self.class.to_resource_name
+      end
+
+      def resource_id
+        id
+      end
+    end
+  end
+end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationRecord < ActiveRecord::Base
+  include Otis::Authorization::Resource
+
   self.abstract_class = true
 end

--- a/app/models/ht_approval_request.rb
+++ b/app/models/ht_approval_request.rb
@@ -44,15 +44,6 @@ class HTApprovalRequest < ApplicationRecord
     find_by_token_hash(digest(tok))
   end
 
-  # Checkpoint
-  def resource_type
-    :ht_approval_request
-  end
-
-  def resource_id
-    id
-  end
-
   # This is the bit that goes to the approver, just a gob of b64 data acting as a 'password'
   def token
     @token ||= SecureRandom.urlsafe_base64 16

--- a/app/models/ht_contact.rb
+++ b/app/models/ht_contact.rb
@@ -14,15 +14,6 @@ class HTContact < ApplicationRecord
 
   self.primary_key = "id"
 
-  # Checkpoint
-  def resource_type
-    :ht_contact
-  end
-
-  def resource_id
-    id
-  end
-
   def institution
     HTInstitution.find(self[:inst_id])
   end

--- a/app/models/ht_contact_type.rb
+++ b/app/models/ht_contact_type.rb
@@ -11,15 +11,6 @@ class HTContactType < ApplicationRecord
 
   self.primary_key = "id"
 
-  # Checkpoint
-  def resource_type
-    :ht_contact_type
-  end
-
-  def resource_id
-    id
-  end
-
   private
 
   def check_contacts

--- a/app/models/ht_institution.rb
+++ b/app/models/ht_institution.rb
@@ -22,15 +22,6 @@ class HTInstitution < ApplicationRecord
   scope :enabled, -> { where("enabled = 1") }
   scope :other, -> { where("enabled != 1") }
 
-  # Checkpoint
-  def resource_type
-    :ht_institution
-  end
-
-  def resource_id
-    id
-  end
-
   def set_defaults
     self.mapto_inst_id ||= inst_id
     return unless entityID

--- a/app/models/ht_user.rb
+++ b/app/models/ht_user.rb
@@ -41,11 +41,7 @@ class HTUser < ApplicationRecord
     HUMANIZED_ATTRIBUTES[attr.to_sym] || super
   end
 
-  # Checkpoint
-  def resource_type
-    :ht_user
-  end
-
+  # Checkpoint override
   def resource_id
     email
   end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ApplicationPolicy
+  def can?(action, object, user)
+    return false if object.nil?
+
+    Checkpoint::Query::ActionPermitted.new(user, action,
+      object.to_resource, authority: authority).true?
+  end
+
+  def authority
+    Services.checkpoint
+  end
+end

--- a/app/policies/ht_approval_requests_policy.rb
+++ b/app/policies/ht_approval_requests_policy.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class HTApprovalRequestsPolicy < ApplicationPolicy
+  def can?(action, object, user)
+    super(action, object, user) || super(action, object.try(:ht_user), user)
+  end
+end

--- a/app/views/ht_users/index.html.erb
+++ b/app/views/ht_users/index.html.erb
@@ -10,7 +10,7 @@
          data-search="true" data-show-search-clear-button="true">
     <thead class="thead-dark">
     <tr>
-      <% if can?(:create, :ht_renewal_requests) || can?(:edit, :ht_users) %>
+      <% if can?(:create, :ht_approval_requests) || can?(:edit, :ht_users) %>
         <th data-sortable="true">Select</th>
       <% end %>
       <th data-sortable="true">E-mail</th>
@@ -26,7 +26,7 @@
 
     <% @users.each do |u| %>
       <tr>
-        <% if can?(:create, :ht_renewal_requests) || can?(:edit, :ht_users) %>
+        <% if can?(:create, :ht_approval_requests) || can?(:edit, :ht_users) %>
           <td><%= u.select_for_renewal_checkbox %></td>
         <% end %>
         <td><%= u.email_link %></td>
@@ -50,7 +50,7 @@
   </table>
   <br/>
 
-  <% if can?(:create, :ht_renewal_requests)  %>
+  <% if can?(:create, :ht_approval_requests)  %>
     <%= button_tag 'Create Approval Requests', type: 'submit', name: 'submit_requests', class: 'btn btn-primary' %>
   <% end %>
   <% if can?(:edit, :ht_users) %>

--- a/lib/tasks/migrate_users.rake
+++ b/lib/tasks/migrate_users.rake
@@ -16,8 +16,8 @@ namespace :otis do
     admin_role = Checkpoint::Credential::Role.new(:admin)
     view_role = Checkpoint::Credential::Role.new(:view)
     res_wildcard = Checkpoint::Resource::AllOfAnyType.new
-    res_contact = Checkpoint::Resource::AllOfType.new(:ht_contacts)
-    res_contact_type = Checkpoint::Resource::AllOfType.new(:ht_contact_types)
+    res_contact = Checkpoint::Resource::AllOfType.new(:ht_contact)
+    res_contact_type = Checkpoint::Resource::AllOfType.new(:ht_contact_type)
     if Otis.config.users.present?
       Otis.config.users.each do |u|
         agent = Checkpoint::Agent::Token.new("user", u)
@@ -35,7 +35,7 @@ namespace :otis do
       end
     end
     if Otis.config.institution.present?
-      res_inst = Checkpoint::Resource::AllOfType.new(:ht_institutions)
+      res_inst = Checkpoint::Resource::AllOfType.new(:ht_institution)
       Otis.config.institution.each do |u|
         agent = Checkpoint::Agent::Token.new("user", u)
         unless Services.checkpoint.permits?(agent, view_role, res_inst)

--- a/test/policies/application_policy_test.rb
+++ b/test/policies/application_policy_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class ApplicationPolicyTest < ActiveSupport::TestCase
+  def setup
+    @user = User.new("application_policy_test@default.invalid")
+    @ht_user = create(:ht_user)
+    agent = Checkpoint::Agent::Token.new("user", @user.id)
+    view_role = Checkpoint::Credential::Role.new(:view)
+    res_users = Checkpoint::Resource::AllOfType.new(:ht_user)
+    Services.checkpoint.grant!(agent, view_role, res_users)
+  end
+
+  test "view credential permits ht_users index" do
+    assert ApplicationPolicy.new.can?(:index, HTUser, @user)
+  end
+
+  test "view credential permits showing a particular HTUser" do
+    assert ApplicationPolicy.new.can?(:show, @ht_user, @user)
+  end
+
+  test "view credential forbids deleting a particular HTUser" do
+    refute ApplicationPolicy.new.can?(:delete, @ht_user, @user)
+  end
+end

--- a/test/policies/ht_approval_requests_policy_test.rb
+++ b/test/policies/ht_approval_requests_policy_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class HTApprovalRequestsPolicyTest < ActiveSupport::TestCase
+  def setup
+    @user = User.new("ht_approval_request_policy_test@default.invalid")
+    @editable_req = create(:ht_approval_request)
+    @uneditable_req = create(:ht_approval_request)
+    agent = Checkpoint::Agent::Token.new("user", @user.id)
+    admin_role = Checkpoint::Credential::Role.new(:admin)
+    res_user = Checkpoint::Resource.new(@editable_req.ht_user)
+    Services.checkpoint.grant!(agent, admin_role, res_user)
+  end
+
+  test "admin credential for HTUser permits editing its HTApprovalRequest" do
+    assert HTApprovalRequestsPolicy.new.can?(:edit, @editable_req, @user)
+  end
+
+  test "admin credential for HTUser does not permit editing unrelated HTApprovalRequest" do
+    refute HTApprovalRequestsPolicy.new.can?(:edit, @uneditable_req, @user)
+  end
+end


### PR DESCRIPTION
- Add Checkpoint policies derived from controller or resource type (more meta stuff than I would have liked, perhaps).
- Address pluralization mismatch between our grants (`lib/tasks/migrate_users.rake`) and model `#resource_type`.
  -  I don't really like the `#resource_type` pluralization route but this preserves the grants we have in production.
- We still don't do any per-object auth checks (i.e., can I edit myself), but we should now be able to if needed.