### PR TITLE
Factorybot & escaping fixes

### DIFF
--- a/test/controllers/ht_contacts_controller_test.rb
+++ b/test/controllers/ht_contacts_controller_test.rb
@@ -266,7 +266,7 @@ class HTContactsControllerEditTest < ActionDispatch::IntegrationTest
     assert_redirected_to ht_contact_path(@contact)
     follow_redirect!
 
-    assert_match CGI.escapeHTML(other_inst.name), @response.body
+    assert_match ERB::Util.html_escape(other_inst.name), @response.body
     assert_equal other_inst.inst_id, HTContact.find(@contact.id).inst_id
   end
 
@@ -280,7 +280,7 @@ class HTContactsControllerEditTest < ActionDispatch::IntegrationTest
     assert_redirected_to ht_contact_path(@contact)
     follow_redirect!
 
-    assert_match other_type.name, @response.body
+    assert_match ERB::Util.html_escape(other_type.name), @response.body
     assert_equal other_type.id, HTContact.find(@contact.id).contact_type.to_i
   end
 

--- a/test/controllers/ht_institutions_controller_test.rb
+++ b/test/controllers/ht_institutions_controller_test.rb
@@ -228,6 +228,9 @@ class HTInstitutionsControllerCreateTest < ActionDispatch::IntegrationTest
       ht_institution: {
         inst_id: inst_params[:inst_id],
         name: inst_params[:name],
+        entityID: inst_params[:inst_id],
+        domain: inst_params[:domain],
+        us: inst_params[:us],
         enabled: inst_params[:enabled],
         ht_billing_member_attributes: {
           marc21_sym: billing_params[:marc21_sym],
@@ -249,6 +252,9 @@ class HTInstitutionsControllerCreateTest < ActionDispatch::IntegrationTest
       ht_institution: {
         inst_id: inst_params[:inst_id],
         name: inst_params[:name],
+        entityID: inst_params[:inst_id],
+        domain: inst_params[:domain],
+        us: inst_params[:us],
         enabled: inst_params[:enabled],
         ht_billing_member_attributes: {
           country_code: "us",

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -41,9 +41,11 @@ FactoryBot.define do
 
   factory :ht_institution do
     sequence(:inst_id) { |n| "#{n}#{Faker::Internet.domain_word}" }
+    domain { Faker::Internet.domain_name }
     name { Faker::University.name }
     entityID { Faker::Internet.url }
     enabled { [0, 1].sample }
+    us { [0, 1].sample }
 
     association :ht_billing_member
 


### PR DESCRIPTION
    - ht_institution factories provide more defaults enforced by NOT NULL (previously omitted from the local schema)
    - Random HTML escaping errors we encountered were fixed