### PR TITLE
HT-3225 fix warning about SASS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,8 +21,8 @@ gem "rails", "~> 5.2.6"
 # gem 'sqlite3'
 # Use Puma as the app server
 gem "puma", "~> 4.3"
-# Use SCSS for stylesheets
-gem "sass-rails", "~> 5.0"
+# Use SCSS/SASS for stylesheets
+gem 'sassc-rails'
 # Use Uglifier as compressor for JavaScript assets
 gem "uglifier", ">= 1.3.0"
 # See https://github.com/rails/execjs#readme for more supported runtimes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,19 +205,14 @@ GEM
     ruby-progressbar (1.11.0)
     ruby_dep (1.5.0)
     rubyzip (2.3.0)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.1.0)
-      railties (>= 5.2.0)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
     sassc (2.4.0)
       ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -296,7 +291,7 @@ DEPENDENCIES
   rails (~> 5.2.6)
   rails-controller-testing
   rubyzip (~> 2.0)
-  sass-rails (~> 5.0)
+  sassc-rails
   selenium-webdriver
   simplecov
   sqlite3

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -44,7 +44,7 @@
       <%= yield %>
     </div>
     <% # Uses bootstrap-table  %>
-    <script src="https://unpkg.com/bootstrap-table@1.15.5/dist/bootstrap-table.min.js"></script>
+    <script src="https://unpkg.com/bootstrap-table@1.18.3/dist/bootstrap-table.min.js"></script>
 
     <script>
        // Add aria-label to bootstrap-table search box.


### PR DESCRIPTION
- Replace deprecated sass-rails with sassc-rails.
- Bump bootstrap-table version to address table border anomaly.