### PR TITLE
HT-3224: Rename database tables

### DIFF
--- a/app/models/ht_approval_request.rb
+++ b/app/models/ht_approval_request.rb
@@ -2,6 +2,8 @@
 
 class HTApprovalRequest < ApplicationRecord
   self.primary_key = "id"
+  self.table_name = "otis_approval_requests"
+
   def self.expiration_date
     Date.today - 1.week
   end

--- a/app/models/ht_contact.rb
+++ b/app/models/ht_contact.rb
@@ -2,6 +2,8 @@
 
 # Map of institution email contact and type
 class HTContact < ApplicationRecord
+  self.table_name = "otis_contacts"
+
   belongs_to :ht_institution, foreign_key: :inst_id, primary_key: :inst_id, required: true
   belongs_to :ht_contact_type, foreign_key: :contact_type, primary_key: :id, required: true
   scope :for_institution, ->(inst_id) { where(inst_id: inst_id).order(:contact_type) }

--- a/app/models/ht_contact_type.rb
+++ b/app/models/ht_contact_type.rb
@@ -2,6 +2,8 @@
 
 # Name and description for type of institution contact
 class HTContactType < ApplicationRecord
+  self.table_name = "otis_contact_types"
+
   validates :name, presence: true, uniqueness: true, allow_blank: false
   validates :description, presence: true, allow_blank: false
 

--- a/app/models/ht_log.rb
+++ b/app/models/ht_log.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class HTLog < ApplicationRecord
+  self.table_name = "otis_logs"
+
   validates :model, presence: true
   validates :objid, presence: true
   validates :data, presence: true

--- a/app/models/ht_registration.rb
+++ b/app/models/ht_registration.rb
@@ -2,6 +2,8 @@
 
 class HTRegistration < ApplicationRecord
   self.primary_key = "id"
+  self.table_name = "otis_registrations"
+
   validates :id, uniqueness: true
 
   belongs_to :ht_institution, foreign_key: :inst_id, primary_key: :inst_id, required: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,7 +18,7 @@ raise StandardError, 'Not for production use' if Rails.env.production?
 ActiveRecord::Schema.define(version: 0) do # rubocop:disable Metrics/BlockLength
   # Tables only used by otis
 
-  create_table :ht_approval_requests do |t|
+  create_table :otis_approval_requests do |t|
     t.string :approver
     t.string :userid
     t.timestamp :sent
@@ -27,25 +27,25 @@ ActiveRecord::Schema.define(version: 0) do # rubocop:disable Metrics/BlockLength
     t.text :token_hash
   end
 
-  create_table :ht_logs do |t|
+  create_table :otis_logs do |t|
     t.string :objid
     t.string :model
     t.timestamp :time
     t.text :data
   end
 
-  create_table :ht_contacts do |t|
+  create_table :otis_contacts do |t|
     t.string :inst_id
     t.integer :contact_type
     t.string :email
   end
 
-  create_table :ht_contact_types do |t|
+  create_table :otis_contact_types do |t|
     t.string :name
     t.text :description
   end
 
-  create_table :ht_registrations do |t|
+  create_table :otis_registrations do |t|
     t.string :inst_id
     t.string :jira_ticket
     t.string :name


### PR DESCRIPTION
This doesn't rename any of the classes in the application, just the
database tables themselves.

Eventually, I think it would make sense to put everything under an `Otis` namespace, e.g.

```ruby
module Otis
  class Registration
   ...
  end
end
```

That requires bigger changes and will almost certainly cause merge conflicts with any other work in progress, so we should probably discuss and coordinate that a bit more when/if we want to do that.