### PR TITLE
Singularize resources for grants

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,7 +33,7 @@ class ApplicationController < ActionController::Base
   # This could be replaced by a landing page that is accessible
   # to everyone.
   def default_path
-    return ht_institutions_path unless can?(:index, :ht_users)
+    return ht_institutions_path unless can?(:index, HTUser)
 
     root_path
   end

--- a/app/views/ht_approval_requests/index.html.erb
+++ b/app/views/ht_approval_requests/index.html.erb
@@ -1,6 +1,6 @@
 <div id="maincontent" class="row">
   <h1>Approval Requests</h1>
-  <% if can?(:edit, :ht_approval_requests) %>
+  <% if can?(:edit, HTApprovalRequest) %>
     <p>To edit and send an approval request email, click on an approver email.</p>
   <% end %>
 
@@ -24,19 +24,19 @@
     <% @incomplete_reqs.each do |req| %>
       <%= tag(:tr, class: @added_users.include?(req.userid) ? :success : nil) %>
         <td>
-          <% if can?(:edit, :ht_approval_requests) %>
+          <% if can?(:edit, HTApprovalRequest) %>
             <%= req.select_for_renewal_checkbox %>
           <% end %>
         </td>
         <td>
-          <% if can?(:edit, :ht_approval_requests) %>
+          <% if can?(:edit, HTApprovalRequest) %>
             <%= req.approver_link %>
           <% else %>
             <%= req.approver %>
           <% end %>
         </td>
         <td>
-          <%= req.userid_link(label: can?(:edit, :ht_approval_requests)) %>
+          <%= req.userid_link(label: can?(:edit, HTApprovalRequest)) %>
         </td>
         <td class="text-nowrap">
           <%= req.sent(short: true) %>
@@ -50,10 +50,10 @@
     <% end %>
   </table>
   <br/>
-  <% if can?(:edit, :ht_users) %>
+  <% if can?(:edit, HTUser) %>
     <%= submit_tag 'Renew Selected Users', name: 'submit_renewals', class: 'btn btn-primary' %>
   <% end %>
-  <% if can?(:destroy, :ht_approval_requests) && HTApprovalRequest.expired.any? %>
+  <% if can?(:destroy, HTApprovalRequest) && HTApprovalRequest.expired.any? %>
     <%= submit_tag 'Delete Expired Requests', name: 'delete_expired', class: 'btn btn-danger',
                    data: { confirm: "Please confirm deletion of #{HTApprovalRequestPresenter.expired_requests}." } %>
   <% end %>

--- a/app/views/ht_contact_types/index.html.erb
+++ b/app/views/ht_contact_types/index.html.erb
@@ -25,7 +25,7 @@
 
   <br />
 
-  <% if can?(:create, :ht_contact_types) %>
+  <% if can?(:create, HTContactType) %>
     <%= link_to 'Add New Contact Type', new_ht_contact_type_path, class: 'btn btn-primary' %>
   <% end %>
 

--- a/app/views/ht_contact_types/show.html.erb
+++ b/app/views/ht_contact_types/show.html.erb
@@ -11,11 +11,11 @@
     </dl>
     <br/>
 
-    <% if can?(:edit, :ht_contact_types) %>
+    <% if can?(:edit, HTContactType) %>
       <%= link_to 'Edit', edit_ht_contact_type_path, class: 'btn btn-primary' %>
     <% end %>
     
-    <% if can?(:destroy, :ht_contact_types) %>
+    <% if can?(:destroy, HTContactType) %>
       <%= link_to 'Delete Contact Type', ht_contact_type_path, method: :delete, class: 'btn btn-danger',
                   data: { confirm: "Please confirm deletion of contact type \"#{@contact_type.name}\"" } %>
     <% end %>

--- a/app/views/ht_contacts/index.html.erb
+++ b/app/views/ht_contacts/index.html.erb
@@ -39,7 +39,7 @@
 
   <br />
 
-  <% if can?(:create, :ht_contacts) %>
+  <% if can?(:create, HTContact) %>
     <%= link_to 'Add New Contact', new_ht_contact_path, class: 'btn btn-primary' %>
   <% end %>
   <% if @contacts.any? %>

--- a/app/views/ht_contacts/show.html.erb
+++ b/app/views/ht_contacts/show.html.erb
@@ -13,11 +13,11 @@
 
    <br />
 
-    <% if can?(:edit, :ht_contacts) %>
+    <% if can?(:edit, HTContact) %>
       <%= link_to 'Edit', edit_ht_contact_path, class: 'btn btn-primary' %>
     <% end %>
 
-    <% if can?(:destroy, :ht_contacts) %>
+    <% if can?(:destroy, HTContact) %>
       <%= link_to 'Delete Contact', ht_contact_path, method: :delete, class: 'btn btn-danger',
                   data: { confirm: "Please confirm deletion of contact \"#{@contact.email}\"" } %>
     <% end %>

--- a/app/views/ht_institutions/index.html.erb
+++ b/app/views/ht_institutions/index.html.erb
@@ -61,7 +61,7 @@
   <%= link_to 'Download CSV', ht_institutions_url(format: :csv), class: 'btn btn-info' %>
   <br />
 
-  <% if can?(:create, :ht_institutions) %>
+  <% if can?(:create, HTInstitution) %>
     <h2> Add New Institution </h2>
 
     <p> <a target="_blank" href="https://met.refeds.org">Search REFEDS Metadata Explorer (opens in new tab)</a> for a SAML

--- a/app/views/ht_institutions/show.html.erb
+++ b/app/views/ht_institutions/show.html.erb
@@ -52,7 +52,7 @@
 
    <br />
 
-    <% if can?(:edit, :ht_institutions) %>
+    <% if can?(:edit, HTInstitution) %>
       <%= link_to 'Edit', edit_ht_institution_path, class: 'btn btn-primary' %>
     <% end %>
 

--- a/app/views/ht_registrations/show.html.erb
+++ b/app/views/ht_registrations/show.html.erb
@@ -28,11 +28,11 @@
   </dl>
   <br />
 
-  <% if can?(:edit, :ht_registrations) %>
+  <% if can?(:edit, HTRegistration) %>
     <%= link_to 'Edit', edit_ht_registration_path, class: 'btn btn-primary' %>
   <% end %>
 
-  <% if can?(:destroy, :ht_registrations) %>
+  <% if can?(:destroy, HTRegistration) %>
     <%= link_to 'Delete Registration', ht_registration_path, method: :delete, class: 'btn btn-danger',
 	data: { confirm: "Please confirm deletion of registration \"#{@registration.name}\"" } %>
   <% end %>

--- a/app/views/ht_users/index.html.erb
+++ b/app/views/ht_users/index.html.erb
@@ -10,7 +10,7 @@
          data-search="true" data-show-search-clear-button="true">
     <thead class="thead-dark">
     <tr>
-      <% if can?(:create, :ht_approval_requests) || can?(:edit, :ht_users) %>
+      <% if can?(:create, HTApprovalRequest) || can?(:edit, HTUser) %>
         <th data-sortable="true">Select</th>
       <% end %>
       <th data-sortable="true">E-mail</th>
@@ -26,7 +26,7 @@
 
     <% @users.each do |u| %>
       <tr>
-        <% if can?(:create, :ht_approval_requests) || can?(:edit, :ht_users) %>
+        <% if can?(:create, HTApprovalRequest) || can?(:edit, HTUser) %>
           <td><%= u.select_for_renewal_checkbox %></td>
         <% end %>
         <td><%= u.email_link %></td>
@@ -50,10 +50,10 @@
   </table>
   <br/>
 
-  <% if can?(:create, :ht_approval_requests)  %>
+  <% if can?(:create, HTApprovalRequest)  %>
     <%= button_tag 'Create Approval Requests', type: 'submit', name: 'submit_requests', class: 'btn btn-primary' %>
   <% end %>
-  <% if can?(:edit, :ht_users) %>
+  <% if can?(:edit, HTUser) %>
     <%= button_tag 'Renew Selected Users', type: 'submit', name: 'submit_renewals', class: 'btn btn-primary' %>
   <% end %>
   <%= link_to 'Download CSV', ht_users_url(format: :csv), class: 'btn btn-info' %>

--- a/app/views/ht_users/show.html.erb
+++ b/app/views/ht_users/show.html.erb
@@ -32,7 +32,7 @@
       <dt>Accesses</dt> <dd><%= @user.ht_count&.accesscount %></dd>
       <dt>Last Access</dt> <dd><%= @user.ht_count&.last_access&.to_s(:db) %></dd>
     </dl>
-    <% if can?(:edit, :ht_users) %>
+    <% if can?(:edit, HTUser) %>
       <%= link_to 'Edit', edit_ht_user_path, class: 'btn btn-primary' %>
     <% end %>
   </div>

--- a/bin/grants
+++ b/bin/grants
@@ -28,7 +28,7 @@ Checkpoint::DB.initialize!
 
 # should get this from the resolvers
 ROLES = ["admin", "view"].freeze
-RESOURCE_TYPES = ["ht_users","ht_institutions","ht_contact_types","ht_contacts"].freeze
+RESOURCE_TYPES = ["ht_user","ht_institution","ht_contact_type","ht_contact"].freeze
 
 def grant
   (username, role, content_type) = ARGV


### PR DESCRIPTION
As far as I can tell, we should now singularize the resource types for
grants, and we can use the class names when calling 'can?'.

There are a number of places wehere we could clean things up by removing
some logic from views and potentially simplifying that logic through
policies, but but changing that is out of the scope of this commit.