### PR TITLE
HT-3304 ht_users should join on inst_id, not entityID

### DIFF
--- a/app/models/ht_institution.rb
+++ b/app/models/ht_institution.rb
@@ -5,7 +5,7 @@ class HTInstitution < ApplicationRecord
   accepts_nested_attributes_for :ht_billing_member, update_only: true
 
   self.primary_key = "inst_id"
-  has_many :ht_users, foreign_key: :identity_provider, primary_key: :entityID
+  has_many :ht_users, foreign_key: :inst_id, primary_key: :inst_id
   has_many :ht_contacts, foreign_key: :inst_id, primary_key: :inst_id
   has_many :ht_registrations, foreign_key: :inst_id, primary_key: :inst_id
   has_many :ht_logs, -> { HTLog.ht_institution }, foreign_key: :objid, primary_key: :inst_id

--- a/app/models/ht_user.rb
+++ b/app/models/ht_user.rb
@@ -6,7 +6,7 @@ require "forwardable"
 class HTUser < ApplicationRecord
   self.primary_key = "email"
 
-  belongs_to :ht_institution, foreign_key: :identity_provider, primary_key: :entityID
+  belongs_to :ht_institution, foreign_key: :inst_id, primary_key: :inst_id
   has_one :ht_count, foreign_key: :userid, primary_key: :userid
   has_many :ht_logs, -> { HTLog.ht_user }, foreign_key: :objid, primary_key: :email
   has_many :ht_approval_request, foreign_key: :userid, primary_key: :email
@@ -17,7 +17,7 @@ class HTUser < ApplicationRecord
   validates :email, presence: true
   validates :userid, presence: true
   validates :expires, presence: true
-  validates :identity_provider, presence: true
+  validates :inst_id, presence: true
   validates :approver, presence: true
 
   validates :mfa, absence: true, unless: -> { ht_institution.shib_authncontext_class.present? }
@@ -154,13 +154,11 @@ class HTUser < ApplicationRecord
   end
 
   def csv_cols
-    extra_cols = ["inst_id", "inst_name"]
-    attributes.keys + extra_cols
+    attributes.keys + ["inst_name"]
   end
 
   def csv_vals
-    extra_vals = [ht_institution.inst_id, institution]
-    attributes.values + extra_vals
+    attributes.values + [institution]
   end
 
   private

--- a/app/presenters/ht_institution_presenter.rb
+++ b/app/presenters/ht_institution_presenter.rb
@@ -99,11 +99,11 @@ class HTInstitutionPresenter < SimpleDelegator
   end
 
   def user_count
-    HTUser.where(identity_provider: entityID).count
+    HTUser.where(inst_id: inst_id).count
   end
 
   def active_user_count
-    HTUser.active.where(identity_provider: entityID).count
+    HTUser.active.where(inst_id: inst_id).count
   end
 
   def contacts

--- a/app/views/ht_users/edit.html.erb
+++ b/app/views/ht_users/edit.html.erb
@@ -68,8 +68,6 @@
         </dd>
         <dt><%= @user.mfa_label %></dt>
         <dd><%= @user.mfa_checkbox %></dd>
-        <dt>Identity Provider:</dt>
-        <dd><%= @user.identity_provider %></dd>
         <dt>Institution:</dt>
         <dd><%= @user.institution %></dd>
       </dl>

--- a/app/views/ht_users/show.html.erb
+++ b/app/views/ht_users/show.html.erb
@@ -24,7 +24,6 @@
       <dt>Renewal Status</dt> <dd><%= @user.badge %></dd>
       <dt>IP Restriction:</dt> <dd><%= @user.iprestrict&.join(', ') %></dd>
       <dt>Multi-Factor?:</dt> <dd><%= @user.mfa_icon %></dd>
-      <dt>Identity Provider:</dt> <dd><%= @user.identity_provider %></dd>
       <dt>Institution:</dt> <dd><%= link_to @user.institution, ht_institution_path(@user.ht_institution.inst_id) %></dd>
     </dl>
     <hr/>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -76,7 +76,8 @@ ActiveRecord::Schema.define(version: 0) do # rubocop:disable Metrics/BlockLength
     t.string :expire_type
     t.string :iprestrict
     t.boolean :mfa
-    t.string :identity_provider
+    t.string :identity_provider # deprecated in favor of inst_id
+    t.string :inst_id
   end
 
   create_table :ht_institutions, id: false do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,9 +28,9 @@ def create_ht_user(expires:)
     mfa: [false, true].sample
   )
   if u.mfa
-    u.identity_provider = HTInstitution.enabled.where.not(shib_authncontext_class: nil).sample.entityID
+    u.inst_id = HTInstitution.enabled.where.not(shib_authncontext_class: nil).sample.inst_id
   else
-    u.identity_provider = HTInstitution.enabled.sample.entityID
+    u.inst_id = HTInstitution.enabled.sample.inst_id
     u.iprestrict = if rand > 0.4
       Faker::Internet.public_ip_v4_address
     elsif rand > 0.2

--- a/test/controllers/ht_users_controller_test.rb
+++ b/test/controllers/ht_users_controller_test.rb
@@ -254,13 +254,13 @@ end
 
 class HTUsersControllerCSVTest < ActionDispatch::IntegrationTest
   def setup
-    @inst1 = create(:ht_institution, entityID: "http://example.com", inst_id: "X", name: "Y")
+    @inst1 = create(:ht_institution, inst_id: "X", name: "Y")
     @user1 = HTUser.new(userid: "a@b", displayname: "A B", email: "c@d",
       activitycontact: "e@f", approver: "g@h",
       authorizer: "i@j", usertype: "staff", role: "ssd",
       access: "total", expires: "2020-01-01 00:00:00",
       expire_type: "expiresannually", iprestrict: "any",
-      mfa: false, identity_provider: "http://example.com")
+      mfa: false, identity_provider: "http://example.com", inst_id: "X")
     @user1.save!
     @user2 = create(:ht_user, :expired, userid: "y@z")
   end

--- a/test/models/ht_user_test.rb
+++ b/test/models/ht_user_test.rb
@@ -41,6 +41,18 @@ class HTUserTest < ActiveSupport::TestCase
   end
 end
 
+class HTUserInstitutionTest < ActiveSupport::TestCase
+  def setup
+    @inst1 = create(:ht_institution, entityID: "http://ok.com", inst_id: "ok")
+    @inst2 = create(:ht_institution, entityID: "http://bogus.com", inst_id: "bogus")
+    @user1 = create(:ht_user, identity_provider: "http://bogus.com", inst_id: "ok")
+  end
+
+  test "joins on inst_id instead of deprecated identity_provider" do
+    assert_equal @inst1, @user1.ht_institution
+  end
+end
+
 class HTUserActiveExpiredTest < ActiveSupport::TestCase
   def setup
     @active = create(:ht_user, :active)


### PR DESCRIPTION
- Add a new column `ht_users.inst_id` while deprecating `ht_users.identity_provider`.
- Do not enforce validity of `inst_id` when creating users since it breaks a number of tests. Right now the UI doesn't allow editing, and registrations restrict selection to menu of institutions, so I'm not too concerned about that right now.
- **This will require a production schema change before rollout.**
  - CRMS uses the field in a routine that appears not to be called currently but this needs to be investigated a bit more deeply.
  - Check in with Roger and Bill for possible issues with MDP lib/tools or whatever might lurk.