### PR TITLE
HT-3156 landing page to confirm user registrations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,7 @@ gem "autoprefixer-rails"
 gem "bootstrap-sass"
 gem "jquery-rails"
 gem "ckeditor"
+gem "whois"
 
 gem "canister"
 gem "ettin"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,6 +283,7 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whois (5.0.2)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.5.3)
@@ -327,6 +328,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   w3c_validators
   web-console (>= 3.3.0)
+  whois
 
 BUNDLED WITH
    2.2.32

--- a/app/controllers/finalize_controller.rb
+++ b/app/controllers/finalize_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Responsible for collecting registration responses from prospective users.
+# As with approval requests, this controller's new page should be
+# the only part of the app that such external users have access to.
+
+class FinalizeController < ApplicationController
+  def new
+    @token = params[:token]
+    @registration = HTRegistration.find_by_token(params[:token])
+    return render_not_found unless @registration&.token_hash
+
+    @already_used = @registration.received.present?
+    @ip_address = request.remote_ip
+    # WHOIS text is not appropriate content for a signup page.
+    # This can be moved into a <pre> block in a ht_registration -> ht_user transmogrification page.
+    # @whois = Whois::Client.new.lookup(@ip_address)
+    if @registration.ht_institution.present?
+      @institution = HTInstitutionPresenter.new @registration.ht_institution
+    end
+    finalize unless @registration.nil? || @registration.expired? || @already_used
+    render "shared/finalize"
+  end
+
+  # Users who cannot access the rest of the application can still use the
+  # one-time links
+  def authorize!
+  end
+
+  private
+
+  def finalize
+    @registration.received = Time.zone.now
+    @registration.save!
+    # Currently, there are no parameters for the controller other than the
+    # token, which we do not wish to log.
+    log_action(@registration, params.permit)
+  end
+end

--- a/app/controllers/ht_registrations_controller.rb
+++ b/app/controllers/ht_registrations_controller.rb
@@ -108,6 +108,10 @@ class HTRegistrationsController < ApplicationController
       finalize_url: finalize_url(@registration.token, host: request.base_url),
       body: params[:email_body]).registration_email.deliver_now
     flash[:notice] = "Message sent"
+    # This is for debugging only
+    if Rails.env.development?
+      flash[:notice] = "Message sent: #{finalize_url @registration.token}"
+    end
     log params.transform_values! { |v| v.present? ? v : nil }.permit!
     @registration.sent = Time.zone.now
     @registration.save!

--- a/app/views/ht_registrations/preview.html.erb
+++ b/app/views/ht_registrations/preview.html.erb
@@ -11,10 +11,9 @@
         <%= cktext_area_tag :email_body, @email_body, ckeditor: { height: '325px' } %>
       </div>
     </div>
-    <% if can?(:mail, :ht_registrations) %>
-      <% ### FIXME: need schema support for @registration.expired? %>
-      <% expired = false %>
-      <% label = expired ? 'RESEND' : 'SEND' %>
+    <% if can?(:mail, :ht_registrations) && !@registration.received? &&
+       (!@registration.sent? || @registration.expired?) %>
+      <% label = @registration.expired? ? 'RESEND' : 'SEND' %>
       <%= submit_tag label, class: 'btn btn-primary' %>
     <% end %>
     <%= link_to 'Cancel', ht_registration_path(@registration), class: 'btn btn-primary' %>

--- a/app/views/shared/finalize.html.erb
+++ b/app/views/shared/finalize.html.erb
@@ -1,0 +1,43 @@
+<div id="maincontent" class="row">
+
+  <% if @registration.expired? %>
+    <strong>Registration for <%= @registration.dsp_email %> has expired.
+            Please contact <%= mail_to ApplicationMailer.default[:from] %>.</strong>
+  <% elsif @already_used %>
+    <strong>This link is no longer valid; it may have already been used.</strong>
+  <% else %>
+    <p><i>WARNING: THE FOLLOWING PLACEHOLDER TEXT HAS NOT BEEN REVIEWED BY THE LEGAL DEPARTMENT.</i></p>
+    <p>Thank you.</p>
+    <p>Elevated access registration confirmed for <strong><%= @registration.dsp_email %></strong>.</p>
+    <p>A HathiTrust staff member will approve your registration and respond shortly by e-mail.</p>
+    
+    <% if @institution.entityID && @institution.shib_authncontext_class %>
+
+      <p>Your registration indicates you have access to multi-factor authentication (MFA).
+        <i>As a reminder, this means than any secure access to HathiTrust must be done
+           through you institution's MFA-enabled sign-in portal.</i>
+      </p>
+      <p>You can test your ability to log in with MFA using the link
+        <%= raw @institution.mfa_test_link %>.
+      </p>
+
+    <% elsif @registration.mfa_addendum? %>
+
+      <% # TODO HT-1212: we want to direct users out and back to pick up MFA info if possible %>
+      <p>Your registration indicates you have access to mult-factor authentication (MFA).
+         HathiTrust staff will take measures to ensure interoperability with your institution's
+         authentication system.</p>
+
+    <% else %>
+
+      <p>Please take a moment to confirm that <code><%= raw @ip_address %></code> is a static IP address.
+         If you are not sure, we recommend you contact your network administrator.</p>
+      <p>This is the only IP address from which you will be able to use the service.
+         If your IP address changes in the future, you will need to contact HathiTrust
+         and/or your network administrator.</p>
+      <p>You can test your ability to log in at HathiTrust using the link
+        <%= @institution.login_test_link %>.</p>
+
+    <% end %>
+  <% end %>
+</div>

--- a/test/controllers/finalize_controller_test.rb
+++ b/test/controllers/finalize_controller_test.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class FinalizeControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @reg = create(:ht_registration, sent: Date.today - 1.day)
+  end
+
+  test "finalization succeeds" do
+    sign_in! username: Faker::Internet.email
+    get finalize_url @reg.token
+    assert_response :success
+    assert_equal "new", @controller.action_name
+    assert_match "confirmed for #{@reg.dsp_email}", ActionView::Base.full_sanitizer.sanitize(@response.body)
+    assert_not_nil @reg.reload.received
+    # Believe it or not, this is just a date comparison
+    assert_equal Date.parse(@reg.reload.received.to_s).to_s, Date.parse(Time.zone.now.to_s).to_s
+  end
+
+  test "does not show nav menu" do
+    sign_in! username: Faker::Internet.email
+    get finalize_url @reg.token
+    assert_response :success
+    assert_no_match "Home", @response.body
+  end
+
+  test "refuses to reprocess a finalized registration" do
+    sign_in!
+    get finalize_url @reg.token
+    assert_response :success
+    get finalize_url @reg.token
+    assert_response :success
+    assert_match "no longer", @response.body
+  end
+
+  test "logs the submitter's session" do
+    sign_in!
+    get finalize_url @reg.token
+
+    assert @reg.ht_logs.first
+  end
+
+  test "logs attributes from keycard" do
+    old_keycard_mode = Keycard.config.access
+    Keycard.config.access = :shibboleth
+
+    begin
+      email = Faker::Internet.email
+
+      sign_in!
+
+      process(:get, finalize_url(@reg.token), headers: {"HTTP_X_SHIB_EDUPERSONPRINCIPALNAME" => email})
+
+      log_data = @reg.ht_logs.first.data
+
+      assert_equal email, log_data["eduPersonPrincipalName"]
+      assert_equal request.remote_ip, log_data["ip_address"]
+    ensure
+      Keycard.config.access = old_keycard_mode
+    end
+  end
+
+  test "does not log token" do
+    sign_in!
+
+    get finalize_url @reg.token
+
+    log_data = @reg.ht_logs.first.data
+    assert_not log_data["params"].key?("token")
+  end
+
+  test "references MFA addendum on success" do
+    sign_in! username: Faker::Internet.email
+    mfa_reg = create(:ht_registration, sent: Date.today - 1.day, mfa_addendum: true)
+    get finalize_url mfa_reg.token
+    assert_match "mult-factor authentication", @response.body
+  end
+
+  test "references static IP on success" do
+    sign_in! username: Faker::Internet.email
+    ip_reg = create(:ht_registration, sent: Date.today - 1.day, mfa_addendum: false)
+    get finalize_url ip_reg.token
+    assert_match "static IP address", @response.body
+  end
+end
+
+class FinalizeControllerFailureTest < ActionDispatch::IntegrationTest
+  def setup
+    @reg = create(:ht_registration, sent: Date.today - 2.day)
+    @unsent = create(:ht_registration)
+    @expired = create(:ht_registration, sent: Date.today - 2.week)
+  end
+
+  test "gets 404 with nonsense token" do
+    sign_in!
+    get finalize_url "asdfghjkl"
+    assert_response :not_found
+  end
+
+  test "gets 404 with unsent approval" do
+    sign_in!
+    get finalize_url @unsent.token
+    assert_response :not_found
+  end
+
+  test "fails approval of expired request" do
+    sign_in!
+    get finalize_url @expired.token
+    assert_response :success
+    assert_match "expired", @response.body
+  end
+end


### PR DESCRIPTION
- Further patterned after what we do with approval requests.
- Not sure about the wording for different MFA/non-MFA scenarios. Expect some cleanup with HT-1212.
- Some new logic for SEND/RESEND link in the e-mail preview.