### PR TITLE
HT-1194 HathiTrust staff member can finalize registration in ht_users

### DIFF
--- a/app/controllers/finalize_controller.rb
+++ b/app/controllers/finalize_controller.rb
@@ -11,10 +11,7 @@ class FinalizeController < ApplicationController
     return render_not_found unless @registration&.token_hash
 
     @already_used = @registration.received.present?
-    @ip_address = request.remote_ip
-    # WHOIS text is not appropriate content for a signup page.
-    # This can be moved into a <pre> block in a ht_registration -> ht_user transmogrification page.
-    # @whois = Whois::Client.new.lookup(@ip_address)
+    @ip_address = ip_address
     @institution = HTInstitutionPresenter.new @registration.ht_institution
     @message_type = if @institution.entityID && @institution.shib_authncontext_class
       :success_mfa
@@ -35,9 +32,22 @@ class FinalizeController < ApplicationController
 
   def finalize
     @registration.received = Time.zone.now
+    @registration.ip_address = @ip_address
+    @registration.env = extract_shib_env
     @registration.save!
     # Currently, there are no parameters for the controller other than the
     # token, which we do not wish to log.
     log_action(@registration, params.permit)
+  end
+
+  # For development and (maybe) testing, visiting this page will taint
+  # the ip_address field with "localhost" and cause a validation error on ht_user
+  # created with this registration. So we use a TEST-NET-1 value.
+  def ip_address
+    Rails.env.production? ? request.remote_ip : "192.0.2.1"
+  end
+
+  def extract_shib_env
+    request.env.select { |k, _v| k.match(/^HTTP_X_SHIB/) || k == "HTTP_X_REMOTE_USER" }.to_json
   end
 end

--- a/app/lib/otis/registration_mover.rb
+++ b/app/lib/otis/registration_mover.rb
@@ -1,0 +1,30 @@
+module Otis
+  # Responsible for creating a new HTUser, populating it with the data in
+  # an HTRegistration, and saving.
+  class RegistrationMover
+    def initialize(registration)
+      @registration = registration
+    end
+
+    def ht_user
+      return @ht_user unless @ht_user.nil?
+
+      headers = JSON.parse(@registration.env || "{}")
+      @ht_user = HTUser.new(userid: headers["HTTP_X_REMOTE_USER"],
+        email: @registration.dsp_email, displayname: @registration.dsp_name,
+        inst_id: @registration.inst_id, approver: @registration.auth_rep_email,
+        authorizer: @registration.auth_rep_email, expire_type: :expiresannually,
+        expires: Time.zone.now + 1.year, usertype: :external, access: :total,
+        role: :ssdproxy)
+      institution = HTInstitution.find(@registration.inst_id)
+      if institution.mfa?
+        @ht_user.mfa = true
+      else
+        @ht_user.iprestrict = @registration.ip_address
+      end
+      @ht_user.tap do |u|
+        u.save
+      end
+    end
+  end
+end

--- a/app/models/ht_registration.rb
+++ b/app/models/ht_registration.rb
@@ -62,6 +62,10 @@ class HTRegistration < ApplicationRecord
     self[:received].present?
   end
 
+  def finished?
+    self[:finished].present?
+  end
+
   def resource_id
     id
   end

--- a/app/models/ht_user.rb
+++ b/app/models/ht_user.rb
@@ -14,6 +14,9 @@ class HTUserRenewalError < StandardError
 end
 
 class HTUser < ApplicationRecord
+  ROLES = %i[corrections cataloging ssdproxy crms quality staffdeveloper staffsysadmin replacement ssd].freeze
+  USERTYPES = %i[staff external student].freeze
+  ACCESSES = %i[total normal].freeze
   self.primary_key = "email"
 
   belongs_to :ht_institution, foreign_key: :inst_id, primary_key: :inst_id
@@ -25,7 +28,7 @@ class HTUser < ApplicationRecord
   validate :validate_iprestrict
   validate :validate_expires
 
-  validates :email, presence: true
+  validates :email, presence: true, uniqueness: true
   validates :userid, presence: true
   validates :expires, presence: true
   validates :inst_id, presence: true

--- a/app/presenters/ht_user_presenter.rb
+++ b/app/presenters/ht_user_presenter.rb
@@ -5,13 +5,12 @@ class HTUserPresenter < ApplicationPresenter
 
   ALL_FIELDS = %i[
     email userid displayname activitycontact approver authorizer usertype
-    role access expire_type expires renewal_status iprestrict mfa
-    identity_provider institution
+    role access expire_type expires renewal_status iprestrict mfa institution
   ].freeze
 
   INDEX_FIELDS = %i[email displayname role institution expires renewal_status iprestrict mfa].freeze
   HT_COUNTS_FIELDS = %i[accesses last_access].freeze
-  READ_ONLY_FIELDS = (ALL_FIELDS + HT_COUNTS_FIELDS - %i[userid iprestrict expires approver mfa]).freeze
+  READ_ONLY_FIELDS = (HT_COUNTS_FIELDS + %i[email activitycontact renewal_status institution]).freeze
   FIELD_SIZE = 40
 
   def self.role_name(role)
@@ -136,6 +135,10 @@ class HTUserPresenter < ApplicationPresenter
     HTApprovalRequestPresenter.new(approval_request)&.badge
   end
 
+  def edit_access(form:)
+    form.select(:access, access_options)
+  end
+
   # NOTE: we do not use localized dates for this because the controller would
   # have to parse localized date formats when the value is edited.
   # There are two gems that may (or may not) be able to do this:
@@ -176,6 +179,26 @@ class HTUserPresenter < ApplicationPresenter
     else
       Otis::Badge.new("ht_user.values.mfa.unavailable", "label-warning").label_span
     end
+  end
+
+  def edit_role(form:)
+    form.select(:role, role_options)
+  end
+
+  def edit_usertype(form:)
+    form.select(:usertype, usertype_options)
+  end
+
+  def access_options
+    @access_options ||= HTUser::ACCESSES.sort.map { |access| [I18n.t("ht_user.values.access.#{access}"), access] }
+  end
+
+  def role_options
+    @role_options ||= HTUser::ROLES.sort.map { |role| [I18n.t("ht_user.values.role.#{role}"), role] }
+  end
+
+  def usertype_options
+    @usertype_options ||= HTUser::USERTYPES.sort.map { |type| [I18n.t("ht_user.values.usertype.#{type}"), type] }
   end
 
   def expiration_badge

--- a/app/views/ht_registrations/index.html.erb
+++ b/app/views/ht_registrations/index.html.erb
@@ -6,12 +6,16 @@
   <h2 class="pull-left"><%= t(".current_registrations") %></h2>
   
   <% fields = HTRegistrationPresenter::INDEX_FIELDS %>
-  <table class="table table-striped" data-toggle="table" data-height="460" data-virtual-scroll="true" data-search="true" data-show-search-clear-button="true">
-    <tr>
-      <% fields.each do |field| %>
-        <th data-sortable="true"><%= HTRegistrationPresenter.field_label field %></th>
-      <% end %>
-    </tr>
+  <table id="registrations-table" class="table table-striped" data-toggle="table"
+         data-height="800" data-virtual-scroll="true" data-search="true"
+         data-show-search-clear-button="true">
+    <thead>
+      <tr>
+        <% fields.each do |field| %>
+          <th data-sortable="true"><%= HTRegistrationPresenter.field_label field %></th>
+        <% end %>
+      </tr>
+    </thead>
     <% @all_registrations.each do |reg| %>
       <tr>
       <% fields.each do |field| %>

--- a/app/views/ht_registrations/show.html.erb
+++ b/app/views/ht_registrations/show.html.erb
@@ -1,6 +1,6 @@
-<div class="col-sm-6">
+<div class="col-sm-12">
   <h1><%= @registration.dsp_name %></h1>
-  
+
   <dl class="dl-horizontal">
     <% @registration.all_fields.each do |field| %>
       <dt><%= @registration.field_label field %></dt>
@@ -9,16 +9,29 @@
   </dl>
   <br/>
 
-  <% if can?(:edit, HTRegistration) %>
-    <%= link_to t(".edit"), edit_ht_registration_path, class: 'btn btn-primary' %>
-  <% end %>
-  
-  <% if can?(:preview, :ht_registrations) %>
-    <%= link_to t(".email_preview"), preview_ht_registration_path, class: 'btn btn-primary' %>
+  <% unless @registration.finished? %>
+    <% if can?(:edit, HTRegistration) %>
+      <%= link_to t(".edit"), edit_ht_registration_path, class: 'btn btn-primary' %>
+    <% end %>
+
+    <% if can?(:preview, HTRegistration) %>
+      <%= link_to t(".email_preview"), preview_ht_registration_path, class: 'btn btn-primary' %>
+    <% end %>
+
+    <% if can?(:destroy, HTRegistration) && !@registration.sent? %>
+      <%= link_to t(".delete"), ht_registration_path, method: :delete, class: 'btn btn-danger',
+            data: { confirm: t(".confirm_delete", name: @registration.dsp_name) } %>
+    <% end %>
+
+    <% if can?(:create, HTUser) && @registration.received? && !HTUser.exists?(@registration.dsp_email) %>
+      <%= link_to t(".create_user"), finish_ht_registration_path, method: :post, class: 'btn btn-success' %>
+    <% end %>
   <% end %>
 
-  <% if can?(:destroy, HTRegistration) && !@registration.sent? %>
-    <%= link_to t(".delete"), ht_registration_path, method: :delete, class: 'btn btn-danger',
-	        data: { confirm: t(".confirm_delete", name: @registration.dsp_name) } %>
+  <% if @whois.present? %>
+    <h2><%= t(".whois_data") %></h2>
+    <div>
+      <pre><%= @whois.to_s %></pre>
+    </div>
   <% end %>
 </div>

--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -25,7 +25,7 @@ Keycard.config.access = Otis.config.keycard&.access || :direct
 
 Services = Canister.new
 
-role_map = {admin: [:create, :destroy, :edit, :index, :new, :save, :show, :update, :preview, :mail],
+role_map = {admin: [:create, :destroy, :edit, :index, :new, :save, :show, :update, :preview, :mail, :finish],
             view: [:index, :show]}
 
 Services.register(:checkpoint) do
@@ -34,3 +34,5 @@ Services.register(:checkpoint) do
     resource_resolver: Checkpoint::Resource::Resolver.new
   )
 end
+
+Services.register(:whois) { Whois::Client.new }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,7 @@ en:
         objid: ID
         time: Time
       ht_registration:
+        access: Access
         auth_rep: Auth Rep
         auth_rep_date: Auth Rep Date
         auth_rep_email: Auth Rep E-mail
@@ -54,11 +55,17 @@ en:
         dsp_date: DSP Date
         dsp_email: DSP E-mail
         dsp_name: DSP Name
+        env: Authentication Data
+        finished: Finished
         inst_id: Institution
+        ip_address: IP Address
         jira_ticket: Ticket
         mfa_addendum: MFA Addendum
         received: Received
+        role: Role
         sent: Sent
+        status: Status
+        usertype: User Type
       ht_user:
         access: Access
         accesses: Accesses
@@ -282,9 +289,11 @@ en:
       send: SEND
     show:
       confirm_delete: Please confirm deletion of registration "%{name}"
+      create_user: Create User
       delete: Delete Registration
       edit: Edit
       email_preview: E-mail Preview
+      whois_data: WHOIS Data
     update:
       success: Registration updated for %{name}.
   ht_user:
@@ -310,8 +319,8 @@ en:
       superuser: UM staff developer – includes roles staffdeveloper and staffsysadmin
     values:
       access:
-        normal: normal
-        total: total
+        normal: Normal
+        total: Total
       expire_type:
         expiresannually: 1 year
         expiresbiannually: 2 years

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -45,6 +45,7 @@ ja:
         objid: ID
         time: 時間
       ht_registration:
+        access: アクセス
         auth_rep: 認証担当者
         auth_rep_date: 認証担当者の年月日
         auth_rep_email: 認証担当者のEメール
@@ -54,11 +55,17 @@ ja:
         dsp_date: DSP年月日
         dsp_email: DSPEメール
         dsp_name: DSP表示名
+        env: 認証データ
+        finished: 終了した
         inst_id: 機関
+        ip_address: IPアドレス
         jira_ticket: チケット
         mfa_addendum: 多要素認証の補遺
         received: 受信した
+        role: 役割
         sent: 送信された
+        status: 状態
+        usertype: ユーザータイプ
       ht_user:
         access: アクセス
         accesses: アクセス数
@@ -282,9 +289,11 @@ ja:
       send: 送信
     show:
       confirm_delete: 登録「%{name}」の削除を確認してください。
+      create_user: ユーザーを作成する
       delete: 登録を削除する
       edit: 編集
       email_preview: Eメールプレビュー
+      whois_data: WHOISデータ
     update:
       success: "%{name}の登録が更新されました。"
   ht_user:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
       member do
         get "preview"
         post "mail"
+        post "finish"
       end
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -60,6 +60,9 @@ ActiveRecord::Schema.define(version: 0) do # rubocop:disable Metrics/BlockLength
     t.text :token_hash
     t.timestamp :sent
     t.timestamp :received
+    t.timestamp :finished
+    t.string :ip_address
+    t.text :env
   end
 
   # Tables also used by other applications; must be kept in sync with

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,9 +20,9 @@ def create_ht_user(expires:)
     activitycontact: Faker::Internet.email,
     approver: @approvers.sample,
     authorizer: Faker::Internet.email,
-    usertype: %w[staff external student].sample,
-    role: %w[corrections cataloging ssdproxy crms quality staffdeveloper staffsysadmin replacement ssd].sample,
-    access: %w[total normal].sample,
+    usertype: HTUser::USERTYPES.sample.to_s,
+    role: HTUser::ROLES.sample.to_s,
+    access: HTUser::ACCESSES.sample.to_s,
     expires: expires,
     expire_type: %w[expiresannually expiresbiannually expirescustom90 expirescustom60].sample,
     mfa: [false, true].sample

--- a/test/presenters/ht_registration_presenter_test.rb
+++ b/test/presenters/ht_registration_presenter_test.rb
@@ -64,7 +64,7 @@ class HTRegistrationPresenterTest < ActiveSupport::TestCase
   end
 
   test "#field_value :inst_id displays as link" do
-    assert_match %r{#{@reg.inst_id}.+>#{@reg.inst_id}<}, @reg.field_value(:inst_id)
+    assert_match "href", @reg.field_value(:inst_id)
   end
 
   test "#field_value :mfa_addendum displays as icon when set" do

--- a/test/presenters/ht_user_presenter_test.rb
+++ b/test/presenters/ht_user_presenter_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 class HTUserPresenterTest < ActiveSupport::TestCase
   test "class constants" do
     assert_not_nil HTUserPresenter::ALL_FIELDS
-    assert_equal 16, HTUserPresenter::ALL_FIELDS.count
+    assert_equal 15, HTUserPresenter::ALL_FIELDS.count
     assert_not_nil HTUserPresenter::INDEX_FIELDS
     assert_equal 8, HTUserPresenter::INDEX_FIELDS.count
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,14 @@ require_relative "../config/environment"
 require_relative "fake_form"
 require "rails/test_help"
 
+Services.register(:whois) do
+  Class.new do
+    def lookup(ip)
+      "TOTALLY LEGIT WHOIS for #{ip}"
+    end
+  end.new
+end
+
 def sign_in!(username: "admin@default.invalid")
   post login_as_url, params: {username: username}
 end
@@ -21,6 +29,10 @@ def check_w3c_errs
   yield
   sleep 1
   assert_equal [], W3CValidators::NuValidator.new.validate_text(@response.body).errors
+end
+
+def fake_shib_id
+  "#{Faker::Internet.url}!#{Faker::Internet.url}!#{SecureRandom.urlsafe_base64 16}"
 end
 
 Keycard::DB.migrate!


### PR DESCRIPTION
- Add app/lib/otis/registration_mover.rb for stuffing registration data into new user.
- Add ability to edit ht_user usertype, role, access for newly-registered users.
- Display WHOIS data on registration show page for received registrations (we have the IP address).