### PR TITLE
HT-3360 Keyboard-aware institution pop-up menu

### DIFF
--- a/app/presenters/ht_contact_presenter.rb
+++ b/app/presenters/ht_contact_presenter.rb
@@ -22,7 +22,8 @@ class HTContactPresenter < ApplicationPresenter
   end
 
   def edit_inst_id(form:)
-    form.collection_select(:inst_id, HTInstitution.enabled.all, :inst_id, :name)
+    form.collection_select(:inst_id, HTInstitution.enabled.all, :inst_id, :name,
+      {}, {class: "select-institution"})
   end
 
   def edit_contact_type(form:)

--- a/app/presenters/ht_registration_presenter.rb
+++ b/app/presenters/ht_registration_presenter.rb
@@ -107,7 +107,8 @@ class HTRegistrationPresenter < ApplicationPresenter
   end
 
   def edit_inst_id(form:)
-    form.collection_select(:inst_id, HTInstitution.enabled.all, :inst_id, :name)
+    form.collection_select(:inst_id, HTInstitution.enabled.all, :inst_id, :name,
+      {}, {class: "select-institution"})
   end
 
   def edit_mfa_addendum(form:)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,13 @@
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
 
+    <% # Select2 (select2.org) main distro, locale files, CSS %>
+    <%= javascript_include_tag "https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js" %>
+    <% I18n.available_locales.each do |locale| %>
+      <%= javascript_include_tag "https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/i18n/#{locale.to_s}.js" %>
+    <% end %>
+    <%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" %>
+
     <%= stylesheet_link_tag("https://unpkg.com/bootstrap-table@1.18.3/dist/bootstrap-table.min.css") %>
 
     <% # Keyboard-related overrides that trigger when a bootstrap-table search  %>
@@ -57,8 +64,12 @@
          $('.search-input').each(function (index) {
            $(this).attr('aria-label', 'Search');
          });
+
+         $(".select-institution").select2({
+           language: "<%= params[:locale] %>",
+           width: "100%"
+          });
        });
      </script>
-
   </body>
 </html>


### PR DESCRIPTION
- Use Select2 (select2.org) which appears to be the JS used by HT WAYF.
- Also use Select2 locale files for each of our available locales.
- This facility is currently used only for institution select menus used with registrations and contacts.