### PR TITLE
HT-3362 Registration e-mail subject line should be editable

### DIFF
--- a/app/controllers/ht_approval_requests_controller.rb
+++ b/app/controllers/ht_approval_requests_controller.rb
@@ -39,7 +39,8 @@ class HTApprovalRequestsController < ApplicationController
 
   def update
     begin
-      ApprovalRequestMailer.with(reqs: @reqs, base_url: request.base_url, body: params[:email_body]).approval_request_email.deliver_now
+      ApprovalRequestMailer.with(reqs: @reqs, base_url: request.base_url,
+        body: params[:email_body], subject: params[:subject]).approval_request_email.deliver_now
       @reqs.each do |req|
         next unless req.mailable?
 

--- a/app/controllers/ht_registrations_controller.rb
+++ b/app/controllers/ht_registrations_controller.rb
@@ -127,7 +127,7 @@ class HTRegistrationsController < ApplicationController
   def send_mail
     RegistrationMailer.with(registration: @registration,
       finalize_url: finalize_url(@registration.token, host: request.base_url),
-      body: params[:email_body]).registration_email.deliver_now
+      body: params[:email_body], subject: params[:subject]).registration_email.deliver_now
     flash[:notice] = t("ht_registrations.mail.success")
     # This is for debugging only
     if Rails.env.development?

--- a/app/mailers/approval_request_mailer.rb
+++ b/app/mailers/approval_request_mailer.rb
@@ -9,11 +9,12 @@ class ApprovalRequestMailer < ApplicationMailer
     @reqs = params[:reqs]
     @base_url = params[:base_url]
     @body = params[:body]
+    @subject = params[:subject] || ApprovalRequestMailer.subject
     raise StandardError, "Cannot send an email without at least one approval request" unless @reqs.count.positive?
 
     approvers = @reqs.pluck(:approver).uniq
     raise StandardError, "Approval request e-mail must be for a single approver" unless approvers.count == 1
 
-    mail(to: approvers.first, subject: ApprovalRequestMailer.subject)
+    mail(to: approvers.first, subject: @subject)
   end
 end

--- a/app/mailers/registration_mailer.rb
+++ b/app/mailers/registration_mailer.rb
@@ -7,9 +7,10 @@ class RegistrationMailer < ApplicationMailer
 
   def registration_email
     @registration = params[:registration]
+    @subject = params[:subject] || RegistrationMailer.subject
     raise StandardError, "Cannot send email without a registration" unless @registration.present?
     @base_url = params[:base_url]
     @body = params[:body]
-    mail(to: @registration.dsp_email, subject: RegistrationMailer.subject)
+    mail(to: @registration.dsp_email, subject: @subject)
   end
 end

--- a/app/views/ht_approval_requests/edit.html.erb
+++ b/app/views/ht_approval_requests/edit.html.erb
@@ -1,4 +1,7 @@
 <%= javascript_include_tag Ckeditor.cdn_url %>
+<script>
+  CKEDITOR.config.language = "<%= I18n.locale %>";
+</script>
 
 <div id="maincontent" class="row">
   <h1><%= t ".requests_for", approver: params[:id] %></h1>
@@ -21,17 +24,18 @@
       <%= form_tag ht_approval_request_path, method: :put do %>
         <div class="panel panel-default">
           <div class="panel-heading"><%= t ".email_preview" %></div>
-          <!-- Turn off locale setting for mail preview -->
-          <!-- e-mail content language is orthogonal to UI language -->
-          <% I18n.with_locale(I18n.default_locale) do %>
             <div class="panel-body">
-              <%= cktext_area_tag :email_body, @email_body, ckeditor: { height: '325px',
-                                                                        language: 'de' } %>
+              <%= label_tag "subject", t(".subject") %>
+              <%= text_field_tag "subject", ApprovalRequestMailer.subject, size: 60 %>
+              <%= cktext_area_tag :email_body, @email_body, ckeditor: { height: '325px' } %>
             </div>
             <div class="panel-body">
-              <%= render 'shared/approval_request_user_table' %>
+              <!-- Turn off locale setting since this is part of mail preview -->
+              <!-- e-mail content language is orthogonal to UI language -->
+              <% I18n.with_locale(I18n.default_locale) do %>
+                <%= render 'shared/approval_request_user_table' %>
+              <% end %>
             </div>
-          <% end %> <!-- default locale -->
         </div>
         <% label = counts[:expired]&.positive? ? t(".resend") : t(".send") %>
         <%= submit_tag label, class: 'btn btn-primary' %>

--- a/app/views/ht_registrations/preview.html.erb
+++ b/app/views/ht_registrations/preview.html.erb
@@ -1,4 +1,7 @@
 <%= javascript_include_tag Ckeditor.cdn_url %>
+<script>
+  CKEDITOR.config.language = "<%= I18n.locale %>";
+</script>
 
 <div id="maincontent" class="row">
   <h1><%= @registration.dsp_name %></h1>
@@ -8,6 +11,8 @@
     <div class="panel panel-default">
       <div class="panel-heading"><%= t ".email_preview" %></div>
       <div class="panel-body">
+        <%= label_tag "subject", t(".subject") %>
+        <%= text_field_tag "subject", RegistrationMailer.subject, size: 60 %>
         <%= cktext_area_tag :email_body, @email_body, ckeditor: { height: '325px' } %>
       </div>
     </div>
@@ -20,4 +25,3 @@
   <% end %>
   </div>
 </div>
-

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -66,7 +66,7 @@
          });
 
          $(".select-institution").select2({
-           language: "<%= params[:locale] %>",
+           language: "<%= I18n.locale %>",
            width: "100%"
           });
        });

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -164,6 +164,7 @@ en:
       requests_for: Approval Requests for %{approver}
       resend: RESEND
       send: SEND
+      subject: Subject
     index:
       active_requests: Active Requests
       approval_requests: Approval Requests
@@ -287,6 +288,7 @@ en:
       email_preview: E-mail Preview
       resend: RESEND
       send: SEND
+      subject: Subject
     show:
       confirm_delete: Please confirm deletion of registration "%{name}"
       create_user: Create User

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -164,6 +164,7 @@ ja:
       requests_for: "%{approver}の承認リクエスト"
       resend: 再送
       send: 送信
+      subject: 件名
     index:
       active_requests: アクティブなリクエスト
       approval_requests: 承認リクエスト
@@ -287,6 +288,7 @@ ja:
       email_preview: Eメールプレビュー
       resend: 再送
       send: 送信
+      subject: 件名
     show:
       confirm_delete: 登録「%{name}」の削除を確認してください。
       create_user: ユーザーを作成する

--- a/test/controllers/ht_approval_requests_controller_test.rb
+++ b/test/controllers/ht_approval_requests_controller_test.rb
@@ -151,6 +151,12 @@ class HTApprovalRequestControllerUpdateTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "should use provided email subject line" do
+    test_subject = Faker::Lorem.sentence
+    patch_approval_request params: {subject: test_subject}
+    assert_match test_subject, ActionMailer::Base.deliveries.first.subject
+  end
+
   test "should send mail" do
     patch_approval_request
 

--- a/test/controllers/ht_registrations_controller_test.rb
+++ b/test/controllers/ht_registrations_controller_test.rb
@@ -308,6 +308,12 @@ class HTRegistrationsControllerMailTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "should use provided email subject line" do
+    test_subject = Faker::Lorem.sentence
+    mail_registration params: {subject: test_subject}
+    assert_match test_subject, ActionMailer::Base.deliveries.first.subject
+  end
+
   test "should send mail" do
     mail_registration
 


### PR DESCRIPTION
- Approval request UI updated for feature parity.
- ckeditor UI language synchronized with OTIS locale.
- Borked-up 'de' locale setting for ckeditor (left over from big localization experiment) fixed.
- Use `I18n.locale` instead of `params[:locale]`.