### PR TITLE
DEV-49 allow deletion of sent registration

### DIFF
--- a/app/views/ht_registrations/show.html.erb
+++ b/app/views/ht_registrations/show.html.erb
@@ -18,7 +18,7 @@
       <%= link_to t(".email_preview"), preview_ht_registration_path, class: 'btn btn-primary' %>
     <% end %>
 
-    <% if can?(:destroy, HTRegistration) && !@registration.sent? %>
+    <% if can?(:destroy, HTRegistration) && !@registration.received? && !@registration.finished? %>
       <%= link_to t(".delete"), ht_registration_path, method: :delete, class: 'btn btn-danger',
             data: { confirm: t(".confirm_delete", name: @registration.dsp_name) } %>
     <% end %>

--- a/test/controllers/ht_registrations_controller_test.rb
+++ b/test/controllers/ht_registrations_controller_test.rb
@@ -87,13 +87,33 @@ class HTRegistrationsControllerShowTest < ActionDispatch::IntegrationTest
     assert_match "<strong>HTTP_X_REMOTE_USER</strong>", @response.body
   end
 
-  test "finished registration no longer shows edit, mail, delete, or finish buttons" do
+  test "sent registration shows edit, preview, and delete buttons" do
+    sent_registration = create(:ht_registration, sent: Time.zone.now - 1.day,
+      received: nil, finished: nil)
+    get ht_registration_url sent_registration
+    assert_match edit_ht_registration_path(sent_registration), @response.body
+    assert_match preview_ht_registration_path(sent_registration), @response.body
+    assert_select "a[data-method='delete']"
+    assert_no_match finish_ht_registration_path(sent_registration), @response.body
+  end
+
+  test "received but not finished registration shows only edit, preview, and create user buttons" do
+    sent_registration = create(:ht_registration, sent: Time.zone.now - 1.day,
+      received: Time.zone.now - 1.day, finished: nil)
+    get ht_registration_url sent_registration
+    assert_match edit_ht_registration_path(sent_registration), @response.body
+    assert_match preview_ht_registration_path(sent_registration), @response.body
+    assert_select "a[data-method='delete']", false
+    assert_match finish_ht_registration_path(sent_registration), @response.body
+  end
+
+  test "finished registration no longer shows edit, preview, delete, or create user buttons" do
     finished_registration = create(:ht_registration, finished: Time.zone.now - 1.day)
     get ht_registration_url finished_registration
     assert_no_match edit_ht_registration_path(finished_registration), @response.body
     assert_no_match preview_ht_registration_path(finished_registration), @response.body
-    assert_no_match ht_registration_path(finished_registration, method: :delete), @response.body
-    assert_no_match finish_ht_registration_path(finished_registration, method: :post), @response.body
+    assert_select "a[data-method='delete']", false
+    assert_no_match finish_ht_registration_path(finished_registration), @response.body
   end
 end
 


### PR DESCRIPTION
- Sent registrations can be deleted just like unsent ones.
- Once received or finished the option to delete disappears (another strategy must be used for auto-hiding or removing old data).
- Use `assert_select` in tests as it is more reliable than string matching with path helpers.