### PR TITLE
Add employee affiliation by default

### DIFF
--- a/app/models/ht_institution.rb
+++ b/app/models/ht_institution.rb
@@ -35,7 +35,7 @@ class HTInstitution < ApplicationRecord
     self.domain = metadata.domain
     self.inst_id = metadata.domain_base
     self.mapto_inst_id = metadata.domain_base
-    self.allowed_affiliations = "^(member|alum|faculty|staff|student)@(#{metadata.scopes.join("|")})"
+    self.allowed_affiliations = "^(member|alum|faculty|staff|student|employee)@(#{metadata.scopes.join("|")})"
   end
 
   def mfa?


### PR DESCRIPTION
Some institutions use the employee affiliation; it is worthwhile to be consistent and generous in terms of what we can accept to reduce support issues later.