### PR TITLE
DEV-50 Update registration form fields to match new registration form.

### DIFF
--- a/app/controllers/finalize_controller.rb
+++ b/app/controllers/finalize_controller.rb
@@ -7,7 +7,7 @@
 class FinalizeController < ApplicationController
   def new
     @token = params[:token]
-    @registration = HTRegistration.find_by_token(params[:token])
+    fetch_registration
     return render_not_found unless @registration&.token_hash
 
     @ip_address = ip_address
@@ -66,7 +66,7 @@ class FinalizeController < ApplicationController
   end
 
   def add_jira_comment
-    comment = Otis::JiraClient.comment template: :registration_received, user: @registration.dsp_email
+    comment = Otis::JiraClient.comment template: :registration_received, user: @registration.applicant_email
     Otis::JiraClient.new.comment! issue: @registration.jira_ticket, comment: comment
   end
 end

--- a/app/controllers/ht_registrations_controller.rb
+++ b/app/controllers/ht_registrations_controller.rb
@@ -4,16 +4,18 @@ class HTRegistrationsController < ApplicationController
   before_action :fetch_institutions
 
   PERMITTED_FIELDS = %i[
+    applicant_name
+    applicant_email
+    applicant_date
     inst_id
-    name
     jira_ticket
+    role
+    expire_type
     contact_info
     auth_rep_name
     auth_rep_email
     auth_rep_date
-    dsp_name
-    dsp_email
-    dsp_date
+    hathitrust_authorizer
     mfa_addendum
   ].freeze
 
@@ -29,7 +31,7 @@ class HTRegistrationsController < ApplicationController
     @registration = presenter HTRegistration.new(reg_params)
     if @registration.save
       log
-      flash.now[:notice] = t(".success", name: @registration.dsp_name)
+      flash.now[:notice] = t(".success", name: @registration.applicant_name)
       redirect_to preview_ht_registration_path(@registration.id)
     else
       flash.now[:alert] = @registration.errors.full_messages.to_sentence
@@ -49,7 +51,7 @@ class HTRegistrationsController < ApplicationController
     fetch_presenter
     if @registration.update(reg_params)
       log
-      flash[:notice] = t(".success", name: @registration.dsp_name)
+      flash[:notice] = t(".success", name: @registration.applicant_name)
       redirect_to action: :show
     else
       flash.now[:alert] = @registration.errors.full_messages.to_sentence
@@ -61,7 +63,7 @@ class HTRegistrationsController < ApplicationController
     fetch_presenter
     @base_url = request.base_url
     @email_body = render_to_string(partial: "shared/registration_body")
-      .gsub("__NAME__", @registration.dsp_name)
+      .gsub("__NAME__", @registration.applicant_name)
   end
 
   def mail
@@ -142,7 +144,7 @@ class HTRegistrationsController < ApplicationController
 
   # Adds comment from {:registration_sent, :registration_finished}
   def add_jira_comment(template:)
-    comment = Otis::JiraClient.comment template: template, user: @registration.dsp_email
+    comment = Otis::JiraClient.comment template: template, user: @registration.applicant_email
     Otis::JiraClient.new.comment! issue: @registration.jira_ticket, comment: comment
   end
 end

--- a/app/mailers/registration_mailer.rb
+++ b/app/mailers/registration_mailer.rb
@@ -14,6 +14,6 @@ class RegistrationMailer < ApplicationMailer
     @subject = params[:subject] || RegistrationMailer.subject
     @body = params[:body]
     attachments.inline["HathiTrust_logo.png"] = File.read("#{Rails.root}/app/assets/images/HathiTrust_logo.png")
-    mail(to: @registration.dsp_email, subject: @subject)
+    mail(to: @registration.applicant_email, subject: @subject)
   end
 end

--- a/app/models/expiration_date.rb
+++ b/app/models/expiration_date.rb
@@ -19,10 +19,12 @@ class ExpirationDate
   end
 
   EXPIRES_TYPE = {
-    expiresannually: ExpiresTypeData.new("1 year", 1.year).freeze,
     expiresbiannually: ExpiresTypeData.new("2 years", 2.years).freeze,
+    expiresannually: ExpiresTypeData.new("1 year", 1.year).freeze,
+    expirescustom180: ExpiresTypeData.new("180 days", 180.days).freeze,
+    expirescustom90: ExpiresTypeData.new("90 days", 90.days).freeze,
     expirescustom60: ExpiresTypeData.new("60 days", 60.days).freeze,
-    expirescustom90: ExpiresTypeData.new("90 days", 90.days).freeze
+    expirescustom30: ExpiresTypeData.new("30 days", 30.days).freeze
   }.freeze
 
   # Shared utility for converting a (mostly) arbitrary value into a Date.

--- a/app/models/ht_user.rb
+++ b/app/models/ht_user.rb
@@ -17,6 +17,7 @@ class HTUser < ApplicationRecord
   ROLES = %i[corrections cataloging ssdproxy crms quality staffdeveloper staffsysadmin replacement ssd].freeze
   USERTYPES = %i[staff external student].freeze
   ACCESSES = %i[total normal].freeze
+  EXPIRES_TYPES = ExpirationDate::EXPIRES_TYPE.collect { |k, _v| k }.freeze
   self.primary_key = "email"
 
   belongs_to :ht_institution, foreign_key: :inst_id, primary_key: :inst_id

--- a/app/views/finalize/show.html.erb
+++ b/app/views/finalize/show.html.erb
@@ -1,11 +1,11 @@
 <div id="maincontent" class="row">
 
   <% if @registration.expired? %>
-    <p><%= t ".expired_html", user: @registration.dsp_email,
+    <p><%= t ".expired_html", user: @registration.applicant_email,
              mailto: mail_to(ApplicationMailer.default[:from]) %></p>
     </p>
   <% else %>
-    <%= t ".success_html", user: @registration.dsp_email %>
+    <%= t ".success_html", user: @registration.applicant_email %>
     <% case @message_type %>
     <% when :success_mfa %>
       <%= t ".success_mfa_html",

--- a/app/views/ht_registrations/preview.html.erb
+++ b/app/views/ht_registrations/preview.html.erb
@@ -4,7 +4,7 @@
 </script>
 
 <div id="maincontent" class="row">
-  <h1><%= @registration.dsp_name %></h1>
+  <h1><%= @registration.applicant_name %></h1>
   <div class="row">
   <!-- MAIL PREVIEW -->
   <%= form_tag mail_ht_registration_path, method: :post do %>

--- a/app/views/ht_registrations/show.html.erb
+++ b/app/views/ht_registrations/show.html.erb
@@ -1,5 +1,5 @@
 <div class="col-sm-12">
-  <h1><%= @registration.dsp_name %></h1>
+  <h1><%= @registration.applicant_name %></h1>
 
   <dl class="dl-horizontal">
     <% @registration.all_fields.each do |field| %>
@@ -31,10 +31,10 @@
 
     <% if can?(:destroy, HTRegistration) && !@registration.received? && !@registration.finished? %>
       <%= link_to t(".delete"), ht_registration_path, method: :delete, class: 'btn btn-danger',
-            data: { confirm: t(".confirm_delete", name: @registration.dsp_name) } %>
+            data: { confirm: t(".confirm_delete", name: @registration.applicant_name) } %>
     <% end %>
 
-    <% if can?(:create, HTUser) && @registration.received? && !HTUser.exists?(@registration.dsp_email) %>
+    <% if can?(:create, HTUser) && @registration.received? && !HTUser.exists?(@registration.applicant_email) %>
       <%= link_to t(".create_user"), finish_ht_registration_path, method: :post, class: 'btn btn-success' %>
     <% end %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,6 +46,10 @@ en:
         time: Time
       ht_registration:
         access: Access
+        applicant: Applicant
+        applicant_date: Applicant Date
+        applicant_email: Applicant E-mail
+        applicant_name: Applicant Name
         auth_rep: Auth Rep
         auth_rep_date: Auth Rep Date
         auth_rep_email: Auth Rep E-mail
@@ -58,12 +62,10 @@ en:
         detail_identity_provider: Identity Provider
         detail_reverse_lookup: Reverse Lookup
         detail_scoped_affiliation: Scoped Affiliation
-        dsp: Disability Service Provider
-        dsp_date: DSP Date
-        dsp_email: DSP E-mail
-        dsp_name: DSP Name
         env: Authentication Data
+        expire_type: Expire Type
         finished: Finished
+        hathitrust_authorizer: HathiTrust Authorizer
         inst_id: Institution
         institution:
           mfa: MFA
@@ -281,6 +283,13 @@ en:
     index:
       download_json: Download JSON
       logs: Logs
+  ht_registration:
+    values:
+      role:
+        atrs: Accessible Text Request Service
+        crms: Copyright Review
+        quality: Quality Review
+        staffdeveloper: Staff Developer
   ht_registrations:
     create:
       success: Registration created for %{name}.
@@ -342,6 +351,8 @@ en:
       expire_type:
         expiresannually: 1 year
         expiresbiannually: 2 years
+        expirescustom180: 180 days
+        expirescustom30: 30 days
         expirescustom60: 60 days
         expirescustom90: 90 days
       iprestrict:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -46,6 +46,10 @@ ja:
         time: 時間
       ht_registration:
         access: アクセス
+        applicant: 申請者
+        applicant_date: 申請者の年月日s
+        applicant_email: 申請者のEメール
+        applicant_name: 申請者の表示名
         auth_rep: 認証担当者
         auth_rep_date: 認証担当者の年月日
         auth_rep_email: 認証担当者のEメール
@@ -58,12 +62,10 @@ ja:
         detail_identity_provider: IDプロバイダー
         detail_reverse_lookup: 逆引き
         detail_scoped_affiliation: スコープ付き所属
-        dsp: 障害者サービスプロバイダー
-        dsp_date: DSP年月日
-        dsp_email: DSPEメール
-        dsp_name: DSP表示名
         env: 認証データ
+        expire_type: 有効期限タイプ
         finished: 終了した
+        hathitrust_authorizer: HathiTrustの認証担当者
         inst_id: 機関
         institution:
           mfa: 多要素認証
@@ -281,6 +283,13 @@ ja:
     index:
       download_json: JSONをダウンロード
       logs: ログ
+  ht_registration:
+    values:
+      role:
+        atrs: アクセス可能なテキストリクエストサービス
+        crms: 著作権レビュー
+        quality: 品質レビュー
+        staffdeveloper: スタッフ開発者
   ht_registrations:
     create:
       success: "%{name}の登録が作成されました。"
@@ -342,6 +351,8 @@ ja:
       expire_type:
         expiresannually: 1年間
         expiresbiannually: 2年間
+        expirescustom180: 180日間
+        expirescustom30: 30日間
         expirescustom60: 60日間
         expirescustom90: 90日間
       iprestrict:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -46,16 +46,23 @@ ActiveRecord::Schema.define(version: 0) do # rubocop:disable Metrics/BlockLength
   end
 
   create_table "ht_web.otis_registrations", if_not_exists: true do |t|
-    t.string :dsp_name
-    t.string :dsp_email
-    t.string :dsp_date
+    t.string :applicant_name
+    t.string :applicant_email
+    t.string :applicant_date
     t.string :inst_id
     t.string :jira_ticket
+    t.string :role
+    t.string :expire_type
     # Institution-level ATRS point of contact
+    # Not preserved when registrant is moved to ht_users
     t.string :contact_info
+    # Map auth_rep_email -> ht_users.approver
     t.string :auth_rep_name
     t.string :auth_rep_email
     t.string :auth_rep_date
+    # Needed for CAA but not for ATRS
+    # Map hathitrust_authorizer -> ht_user.authorizer
+    t.string :hathitrust_authorizer
     t.boolean :mfa_addendum, default: false
     t.text :token_hash
     t.timestamp :sent

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -26,7 +26,7 @@ def create_ht_user(expires:)
     role: HTUser::ROLES.sample.to_s,
     access: HTUser::ACCESSES.sample.to_s,
     expires: expires,
-    expire_type: %w[expiresannually expiresbiannually expirescustom90 expirescustom60].sample,
+    expire_type: HTUser::EXPIRES_TYPES.sample,
     mfa: [false, true].sample
   )
   if u.mfa
@@ -120,14 +120,17 @@ def create_ht_registration(inst_id)
   ticket_no = Faker::Number.between(from: 1000, to: 9999)
 
   HTRegistration.create(
+    applicant_name: Faker::Name.name,
+    applicant_email: Faker::Internet.email,
+    applicant_date: Faker::Date.backward(days: 180),
     auth_rep_name: Faker::Name.name,
     auth_rep_email: Faker::Internet.email,
     auth_rep_date: Faker::Date.backward(days: 180),
+    hathitrust_authorizer: Faker::Internet.email,
     inst_id: inst_id,
+    role: HTRegistration::ROLES.sample.to_s,
+    expire_type: HTUser::EXPIRES_TYPES.sample,
     jira_ticket: "XXX-#{ticket_no}",
-    dsp_name: Faker::Name.name,
-    dsp_email: Faker::Internet.email,
-    dsp_date: Faker::Date.backward(days: 180),
     mfa_addendum: [true, false].sample,
     contact_info: Faker::Internet.email
   )

--- a/test/controllers/finalize_controller_test.rb
+++ b/test/controllers/finalize_controller_test.rb
@@ -24,7 +24,7 @@ class FinalizeControllerTest < ActionDispatch::IntegrationTest
     submit_confirmation
     assert_response :success
     assert_equal "new", @controller.action_name
-    assert_match "confirmed for #{@reg.dsp_email}", ActionView::Base.full_sanitizer.sanitize(@response.body)
+    assert_match "confirmed for #{@reg.applicant_email}", ActionView::Base.full_sanitizer.sanitize(@response.body)
     assert_not_nil @reg.reload.received
     # Believe it or not, this is just a date comparison
     assert_equal Date.parse(@reg.reload.received.to_s).to_s, Date.parse(Time.zone.now.to_s).to_s

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -125,13 +125,16 @@ FactoryBot.define do
 
   factory :ht_registration do
     sequence(:id) { |n| n.to_s }
+    applicant_name { Faker::Name.name }
+    applicant_email { Faker::Internet.email }
+    applicant_date { Faker::Date.backward(days: 180) }
     jira_ticket { Faker::Alphanumeric.alpha(number: 6).upcase }
-    dsp_name { Faker::Name.name }
-    dsp_email { Faker::Internet.email }
-    dsp_date { Faker::Date.backward(days: 180) }
+    role { HTUser::ROLES.sample.to_s }
+    expire_type { HTUser::EXPIRES_TYPES.sample.to_s }
     auth_rep_name { Faker::Name.name }
     auth_rep_email { Faker::Internet.email }
     auth_rep_date { Faker::Date.backward(days: 180) }
+    hathitrust_authorizer { Faker::Internet.email }
     mfa_addendum { [true, false].sample }
     contact_info { Faker::Internet.email }
     association :ht_institution, strategy: :create

--- a/test/mailers/previews/registration_mailer_preview.rb
+++ b/test/mailers/previews/registration_mailer_preview.rb
@@ -8,7 +8,7 @@ class RegistrationMailerPreview < ActionMailer::Preview
     base_url = "http://default.invalid"
     body = controller.render_to_string(partial: "shared/registration_body",
       locals: {"@registration": reg})
-      .gsub("__NAME__", reg.dsp_name)
+      .gsub("__NAME__", reg.applicant_name)
     RegistrationMailer.with(registration: reg, body: body, base_url: base_url)
       .registration_email
   end

--- a/test/mailers/registration_mailer_test.rb
+++ b/test/mailers/registration_mailer_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class RegistrationMailerTest < ActionMailer::TestCase
   def setup
-    @reg = create(:ht_registration, dsp_email: "user@example.com")
+    @reg = create(:ht_registration, applicant_email: "user@example.com")
   end
 
   def email(reg: @reg)

--- a/test/presenters/ht_registration_presenter_test.rb
+++ b/test/presenters/ht_registration_presenter_test.rb
@@ -29,32 +29,20 @@ class HTRegistrationPresenterTest < ActiveSupport::TestCase
   end
 
   test "#field_value :auth_rep_email displays as mailto link" do
-    # Localized value, can't make assumptions about content
     assert_match /mailto/, @reg.field_value(:auth_rep_email)
   end
 
-  test "#field_value :dsp_name displays as link on index page" do
-    reg = HTRegistrationPresenter.new build(:ht_registration), action: :index
-    assert_match "/ht_registrations/#{reg.id}", reg.field_value(:dsp_name)
+  test "#field_value :applicant displays with a link" do
+    assert_match /href/, @reg.field_value(:applicant)
   end
 
-  test "#field_value :dsp_name displays without link elsewhere" do
-    reg = HTRegistrationPresenter.new build(:ht_registration), action: :show
-    assert_no_match "/ht_registrations/#{reg.id}", reg.field_value(:dsp_name)
-  end
-
-  test "#field_value :dsp" do
-    assert_match %r{#{@reg.dsp_name}.+mailto:#{@reg.dsp_email}.+<br/>.+}, @reg.field_value(:dsp)
-  end
-
-  test "#field_value :dsp_date" do
+  test "#field_value :applicant_date" do
     # Localized value, can't make assumptions about content
-    assert_not_nil @reg.field_value(:dsp_date)
+    assert_not_nil @reg.field_value(:applicant_date)
   end
 
-  test "#field_value :dsp_email displays as mailto link" do
-    # Localized value, can't make assumptions about content
-    assert_match /mailto/, @reg.field_value(:dsp_email)
+  test "#field_value :applicant_email displays as mailto link" do
+    assert_match /mailto/, @reg.field_value(:applicant_email)
   end
 
   test "#field_value :jira_ticket displays as link" do
@@ -85,6 +73,10 @@ class HTRegistrationPresenterTest < ActiveSupport::TestCase
 
   test "#field_value :mfa_addendum edits as checkbox" do
     assert_equal "CHECK BOX", @reg.field_value(:mfa_addendum, form: FakeForm.new)
+  end
+
+  test "#field_value :role edits as select menu" do
+    assert_equal "SELECT", @reg.field_value(:role, form: FakeForm.new)
   end
 
   test "#cancel_path for new object goes to index" do

--- a/test/registration_mover_test.rb
+++ b/test/registration_mover_test.rb
@@ -50,4 +50,23 @@ module Otis
       assert ht_user.mfa?
     end
   end
+
+  class RegistrationMoverAuthorizerTest < ActiveSupport::TestCase
+    test "CAA registration uses hathitrust_authorizer for authorizer" do
+      registration = create(:ht_registration, role: "quality",
+        hathitrust_authorizer: "authorizer@hathitrust.org",
+        env: {"HTTP_X_REMOTE_USER" => "nobody@default.invalid"}.to_json)
+      ht_user = RegistrationMover.new(registration).ht_user
+      assert_equal "authorizer@hathitrust.org", ht_user.authorizer
+    end
+
+    test "ATRS registration uses auth_rep_email for authorizer and ignores hathitrust_authorizer" do
+      registration = create(:ht_registration, role: "ssd",
+        auth_rep_email: "authorizer@default.invalid",
+        hathitrust_authorizer: nil,
+        env: {"HTTP_X_REMOTE_USER" => "nobody@default.invalid"}.to_json)
+      ht_user = RegistrationMover.new(registration).ht_user
+      assert_equal "authorizer@default.invalid", ht_user.authorizer
+    end
+  end
 end


### PR DESCRIPTION
- Rename `otis_registrations` fields starting with `dsp_` to `applicant_`.
- Add 30- and 180-day expiration periods introduced in CAA registration form.
- Add `hathitrust_authorizer` field for CAA users.
- Add `role` field with limited set of ATRS + CAA roles (and note that this smaller set will need to be reconciled with what's in `ht_users`).