### PR TITLE
DEV-243 OTIS tests sporadically fail

### DIFF
--- a/app/assets/stylesheets/otis.scss
+++ b/app/assets/stylesheets/otis.scss
@@ -59,3 +59,10 @@ a:visited {
 label a {
   font-weight:400
 }
+
+.complete-registration-link {
+  font-weight: bold;
+  font-family: courier;
+  font-size: 120%;
+  color: #d65d22
+}

--- a/app/views/finalize/edit.html.erb
+++ b/app/views/finalize/edit.html.erb
@@ -1,0 +1,9 @@
+<div id="maincontent" class="row">
+  <%= form_with(model: @registration, url: finalize_url, local: true, method: :get) do |form| %>
+
+  <%= t(".confirm_html") %>
+  <br/><br/>
+  <%= form.submit t(".confirm_registration"), class: 'btn btn-primary' %>
+
+  <% end %>
+</div>

--- a/app/views/finalize/show.html.erb
+++ b/app/views/finalize/show.html.erb
@@ -4,10 +4,7 @@
     <p><%= t ".expired_html", user: @registration.dsp_email,
              mailto: mail_to(ApplicationMailer.default[:from]) %></p>
     </p>
-  <% elsif @already_used %>
-    <p><%= t ".already_used_html" %></p>
   <% else %>
-    <p><i>WARNING: THE FOLLOWING PLACEHOLDER TEXT HAS NOT BEEN REVIEWED BY THE LEGAL DEPARTMENT.</i></p>
     <%= t ".success_html", user: @registration.dsp_email %>
     <% case @message_type %>
     <% when :success_mfa %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -129,12 +129,14 @@ en:
   errors:
     resolv: Unable to look up %{ip_address}
   finalize:
-    new:
-      already_used_html: "<strong>This link is no longer valid; it may have already been used.</strong>"
+    edit:
+      confirm_html: Click on the button to confirm elevated access registration.
+      confirm_registration: Confirm Registration
+    show:
       expired_html: "<strong>Registration for %{user} has expired. Please contact %{mailto}.</strong>"
       success_html: "<p>Thank you.</p> <p>Elevated access registration confirmed for <strong>%{user}</strong>. A HathiTrust staff member will approve your registration and respond shortly by e-mail.</p>"
-      success_mfa_addendum_html: "<p>Your registration indicates you have access to mult-factor authentication (MFA). HathiTrust staff will take measures to ensure interoperability with your institution's authentication system.</p>"
-      success_mfa_html: "<p>Your registration indicates you have access to multi-factor authentication (MFA). <i>As a reminder, this means than any secure access to HathiTrust must be done through you institution's MFA-enabled sign-in portal.</i></p> <p>You can test your ability to log in with MFA using the link %{link}.</p>"
+      success_mfa_addendum_html: "<p>Your registration indicates you have access to multi-factor authentication (MFA). HathiTrust staff will take measures to ensure interoperability with your institution's authentication system.</p>"
+      success_mfa_html: "<p>Your registration indicates you have access to multi-factor authentication (MFA). <i>As a reminder, this means than any secure access to HathiTrust must be done through your institution's MFA-enabled sign-in portal.</i></p> <p>You can test your ability to log in with MFA using the link %{link}.</p>"
       success_static_ip_html: "<p>Please take a moment to confirm that <code>%{ip}</code> is a static IP address. If you are not sure, we recommend you contact your network administrator.</p> <p>This is the only IP address from which you will be able to use the service. If your IP address changes in the future, you will need to contact HathiTrust and/or your network administrator.</p> <p>You can test your ability to log in at HathiTrust using the link %{link}.</p>"
       test_login: Test Login
       test_login_mfa: Test Login with MFA

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -129,8 +129,10 @@ ja:
   errors:
     resolv: "%{ip_address}を検索できません"
   finalize:
-    new:
-      already_used_html: "<strong>このリンクは無効になりました。すでに使用されている可能性があります。</strong>"
+    edit:
+      confirm_html: 昇格されたアクセス登録を確認するには、ボタンをクリックしてください。
+      confirm_registration: 登録を確認する
+    show:
       expired_html: "<strong>%{user}の登録が期限切れになりました。 %{mailto}までご連絡ください。</strong>"
       success_html: "<p>ありがとうございます。</p> <p><strong>%{user}</strong>の昇格されたアクセス登録が確認されました。 HathiTrustのスタッフが登録を承認し、すぐに電子メールで返信します。</p>"
       success_mfa_addendum_html: "<p>登録は、多要素認証（MFA）にアクセスできることを示しています。 HathiTrustのスタッフは、あなたの機関との相互運用性を確保するための措置を講じます 認証システム。</p>"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,6 +10,8 @@
 
 raise StandardError, "Not for production use" if Rails.env.production?
 
+ActiveRecord::Base.connection.execute("DELETE FROM ht_web.otis_registrations")
+
 require "faker"
 
 def create_ht_user(expires:)

--- a/test/models/ip_restriction_test.rb
+++ b/test/models/ip_restriction_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "ip_restriction"
 
 class IPRestrictionTest < ActiveSupport::TestCase
   test "turns a single valid string-formatted IPv4 address into a regular expression" do


### PR DESCRIPTION
- `require "ip_restriction"` seems to cause Minitest to load all of the classes in the file under test, preventing the error from occurring.