### PR TITLE
DEV-243 OTIS tests sporadically fail

### DIFF
--- a/test/models/ip_restriction_test.rb
+++ b/test/models/ip_restriction_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "ip_restriction"
 
 class IPRestrictionTest < ActiveSupport::TestCase
   test "turns a single valid string-formatted IPv4 address into a regular expression" do


### PR DESCRIPTION
- Add `require "ip_restriction"` to test file to prevent occasional uninitialized constant errors.