### PR TITLE
DEV-262 OTIS Registration I18n Warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,7 +204,7 @@ GEM
     oauth (0.5.8)
     orm_adapter (0.5.0)
     parallel (1.21.0)
-    parser (3.1.0.0)
+    parser (3.1.2.0)
       ast (~> 2.4.1)
     pry (0.13.1)
       coderay (~> 1.1)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -44,5 +44,6 @@ Rails.application.configure do
   config.time_zone = "UTC"
 
   # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.i18n.raise_on_missing_translations = true
+  config.i18n.exception_handler = proc { |exception| raise exception.to_exception }
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -286,9 +286,10 @@ en:
   ht_registration:
     values:
       role:
-        atrs: Accessible Text Request Service
         crms: Copyright Review
         quality: Quality Review
+        ssd: Accessible Text Request Service Patron
+        ssdproxy: Accessible Text Request Service Provider
         staffdeveloper: Staff Developer
   ht_registrations:
     create:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -286,9 +286,10 @@ ja:
   ht_registration:
     values:
       role:
-        atrs: アクセス可能なテキストリクエストサービス
         crms: 著作権レビュー
         quality: 品質レビュー
+        ssd: アクセシブルなテキストリクエストサービスパトロン
+        ssdproxy: アクセシブルなテキストリクエストサービスプロバイダー
         staffdeveloper: スタッフ開発者
   ht_registrations:
     create:


### PR DESCRIPTION
- Replace unused `en.ht_registration.values.role.atrs` with `en.ht_registration.values.role.ssd` and `en.ht_registration.values.role.ssdproxy`.
- Force missing translations to throw exceptions in test environment config (some errors just cannot be caught by I18n-tasks).
- Suppress pedantic "warning: parser/current is loading parser/ruby30..." noise by updating `parser` gem.