### PR TITLE
DEV-265 OTIS vs WHOIS

### DIFF
--- a/app/presenters/ht_registration_presenter.rb
+++ b/app/presenters/ht_registration_presenter.rb
@@ -32,6 +32,14 @@ class HTRegistrationPresenter < ApplicationPresenter
     self.class::DETAIL_FIELDS
   end
 
+  def whois_block
+    begin
+      Services.whois.lookup(ip_address).to_s
+    rescue => e
+      I18n.t("errors.whois", err: e.to_s)
+    end.yield_self { |s| "<pre>#{s}</pre>" }.html_safe
+  end
+
   private
 
   def show_auth_rep

--- a/app/views/ht_registrations/show.html.erb
+++ b/app/views/ht_registrations/show.html.erb
@@ -42,7 +42,7 @@
   <% if @registration.ip_address.present? %>
     <h2><%= t(".whois_data") %></h2>
     <div>
-      <pre><%= Services.whois.lookup(@registration.ip_address).to_s %></pre>
+      <%= @registration.whois_block %>
     </div>
   <% end %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="<%= I18n.locale %>">
   <head>
     <title>Otis Elevated Access Tool</title>
     <%= csrf_meta_tags %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -130,6 +130,7 @@ en:
       thanks: Thank you.
   errors:
     resolv: Unable to look up %{ip_address}
+    whois: WHOIS data unavailable (%{err})
   finalize:
     edit:
       confirm_html: Click on the button to confirm elevated access registration.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -130,6 +130,7 @@ ja:
       thanks: ありがとうございます。
   errors:
     resolv: "%{ip_address}を検索できません"
+    whois: WHOISデータは利用できません（%{err}）
   finalize:
     edit:
       confirm_html: 昇格されたアクセス登録を確認するには、ボタンをクリックしてください。

--- a/test/controllers/ht_registrations_controller_test.rb
+++ b/test/controllers/ht_registrations_controller_test.rb
@@ -157,6 +157,18 @@ class HTRegistrationsControllerShowTest < ActionDispatch::IntegrationTest
     assert_select "a[data-method='delete']", false
     assert_no_match finish_ht_registration_path(finished_registration), @response.body
   end
+
+  test "show failure notice when WHOIS lookup fails" do
+    received_registration = create(:ht_registration, received: Time.zone.now - 1.day,
+      ip_address: Faker::Internet.public_ip_v4_address, env: {})
+    begin
+      ENV["SIMULATE_WHOIS_FAILURE"] = "SIMULATE_WHOIS_FAILURE"
+      get ht_registration_url received_registration
+      assert_match "WHOIS data unavailable", @response.body
+    ensure
+      ENV.delete "SIMULATE_WHOIS_FAILURE"
+    end
+  end
 end
 
 class HTRegistrationsControllerCreateTest < ActionDispatch::IntegrationTest

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,9 @@ require "rails/test_help"
 Services.register(:whois) do
   Class.new do
     def lookup(ip)
+      if ENV["SIMULATE_WHOIS_FAILURE"]
+        raise SocketError, "getaddrinfo: Temporary failure in name resolution"
+      end
       "TOTALLY LEGIT WHOIS for #{ip}"
     end
   end.new


### PR DESCRIPTION
- Move WHOIS query from registration show page view to presenter.
- Add WHOIS exception handling and localized error message.
- Add ability to force WHOIS testing stub to throw exception.
- Sneak current locale into `<html>` tag in app layout (to make HTML validators happy).