### PR TITLE
DEV-286 OTIS should not allow new registrations for existing users

### DIFF
--- a/app/controllers/ht_registrations_controller.rb
+++ b/app/controllers/ht_registrations_controller.rb
@@ -29,7 +29,10 @@ class HTRegistrationsController < ApplicationController
 
   def create
     @registration = presenter HTRegistration.new(reg_params)
-    if @registration.save
+    if Otis::RegistrationMover.user_exists? @registration
+      flash.now[:alert] = t(".duplicate", email: @registration.applicant_email)
+      render "new"
+    elsif @registration.save
       log
       flash.now[:notice] = t(".success", name: @registration.applicant_name)
       redirect_to preview_ht_registration_path(@registration.id)

--- a/app/lib/otis/registration_mover.rb
+++ b/app/lib/otis/registration_mover.rb
@@ -4,6 +4,10 @@ module Otis
   class RegistrationMover
     UMICH_IDP = "https://shibboleth.umich.edu/idp/shibboleth"
 
+    def self.user_exists?(registration)
+      HTUser.where(email: registration.applicant_email).exists?
+    end
+
     def initialize(registration)
       @registration = registration
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -292,6 +292,7 @@ en:
         staffdeveloper: Staff Developer
   ht_registrations:
     create:
+      duplicate: A user identified by "%{email}" already exists.
       success: Registration created for %{name}.
     destroy:
       success: Registration removed.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -292,6 +292,7 @@ ja:
         staffdeveloper: スタッフ開発者
   ht_registrations:
     create:
+      duplicate: "「%{email}」というユーザーはすでに存在します。"
       success: "%{name}の登録が作成されました。"
     destroy:
       success: 登録が削除されました。

--- a/test/controllers/ht_registrations_controller_test.rb
+++ b/test/controllers/ht_registrations_controller_test.rb
@@ -230,6 +230,15 @@ class HTRegistrationsControllerCreateTest < ActionDispatch::IntegrationTest
     assert_equal 0, HTRegistration.count
     assert_not_empty flash[:alert]
   end
+
+  test "refuses to create registration for someone already in ht_users" do
+    user = FactoryBot.create(:ht_user)
+    params = attributes_for(:ht_registration, applicant_email: user.email)
+    HTRegistration.delete_all
+    post ht_registrations_url, params: {ht_registration: params}
+    assert_equal 0, HTRegistration.count
+    assert_match "already exists", flash[:alert]
+  end
 end
 
 class HTRegistrationsControllerEditTest < ActionDispatch::IntegrationTest


### PR DESCRIPTION
- Add `RegistrationMover.user_exists?` utility called by registrations controller.
- This seemed like the logical place to put it since that class concerns itself with both registrations and users.