### PR TITLE
DEV-54 fix for OTIS daily digest

### DIFF
--- a/lib/tasks/daily_digest.rake
+++ b/lib/tasks/daily_digest.rake
@@ -3,6 +3,9 @@
 namespace :otis do
   desc "Sends daily to-do list of action items to configured recipients"
   task send_daily_digest: :environment do
+    if ENV["RAKE_DEFAULT_URL_HOST"]
+      ActionMailer::Base.default_url_options[:host] = ENV["RAKE_DEFAULT_URL_HOST"]
+    end
     Otis::DailyDigest.send
   end
 end

--- a/test/lib/tasks/daily_digest_test.rb
+++ b/test/lib/tasks/daily_digest_test.rb
@@ -4,12 +4,32 @@ require "test_helper"
 
 module Otis
   class DailyDigestTaskTest < ActiveSupport::TestCase
+    # Work around ActionMailer::Base habit of clearing deliveries array
+    # after Rake task invocation.
+    class MailSnoop
+      SNOOPED_MAIL = []
+      def self.delivering_email(mail)
+        SNOOPED_MAIL << mail
+      end
+    end
+
     def setup
       Application.load_tasks
     end
 
     test "task runs without errors" do
       Rake::Task["otis:send_daily_digest"].invoke
+    end
+
+    test "link uses default URL host from environment" do
+      ENV["RAKE_DEFAULT_URL_HOST"] = "example.com/otis"
+      create(:ht_user, expires: Date.today - 10)
+      ActionMailer::Base.register_interceptor(MailSnoop)
+      Rake::Task["otis:send_daily_digest"].execute
+      MailSnoop::SNOOPED_MAIL.last.tap do |mail|
+        assert_match "example.com/otis/ht_user", mail.html_part.body.decoded
+      end
+      ActionMailer::Base.unregister_interceptor(MailSnoop)
     end
   end
 end

--- a/test/mailers/daily_digest_mailer_test.rb
+++ b/test/mailers/daily_digest_mailer_test.rb
@@ -4,6 +4,8 @@ require "test_helper"
 
 class DailyDigestMailerTest < ActionMailer::TestCase
   def setup
+    # Give it at least one thing to report.
+    create(:ht_user, expires: Date.today - 10)
     @digest = Otis::DailyDigest.new
   end
 


### PR DESCRIPTION
- Rake task uses ENV['RAKE_DEFAULT_URL_HOST'] for default URL host in ActionMailer config.
- Some peculiar shenanigans required for testing.
- No changes to config for OTIS as a whole.