### PR TITLE
DEV-287 OTIS logs UI sorts on human-readable date

### DIFF
--- a/app/presenters/ht_log_presenter.rb
+++ b/app/presenters/ht_log_presenter.rb
@@ -10,6 +10,8 @@ class HTLogPresenter < ApplicationPresenter
   end
 
   def show_time
-    I18n.l(time, format: :long)
+    # https://stackoverflow.com/a/66646882
+    "<span style=\"display:none\">#{time}</span>" +
+      I18n.l(time, format: :long)
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -187,3 +187,12 @@ end
 5.times do
   create_ht_user(expires: Faker::Time.backward)
 end
+
+10.times do
+  HTLog.create(
+    objid: Faker::Number.within(range: 1..10_000),
+    model: %w[HTApprovalRequest HTUser HTInstitution HTContact HTContactType HTRegistration].sample,
+    time: Faker::Time.backward,
+    data: '{"ip_address"=>"127.0.0.1", "user_agent"=>"WhizzyAgent", "client_ip"=>"127.0.0.1"}'
+  )
+end

--- a/test/presenters/ht_log_presenter_test.rb
+++ b/test/presenters/ht_log_presenter_test.rb
@@ -15,6 +15,8 @@ class HTLogPresenterTest < ActiveSupport::TestCase
 
   test "#field_value :time" do
     log = HTLogPresenter.new(create(:ht_log))
-    assert_equal I18n.l(log.time, format: :long), log.field_value(:time)
+    assert_match I18n.l(log.time, format: :long), log.field_value(:time)
+    # Hidden field for sorting
+    assert_match "display:none", log.field_value(:time)
   end
 end


### PR DESCRIPTION
- Enable sorting logs chronologically by prepending invisible span with numeric date.
- This is a bit of a hack from StackOverflow. A bit more discussion can be found in the ticket comments.
- Add some `HTLog` entries in DB seeding phase.