### PR TITLE
DEV-314 OTIS does not do anything with MFA Addendum

### DIFF
--- a/app/lib/otis/registration_mover.rb
+++ b/app/lib/otis/registration_mover.rb
@@ -15,13 +15,14 @@ module Otis
     def ht_user
       return @ht_user unless @ht_user.nil?
 
+      institution = HTInstitution.find(@registration.inst_id)
       @ht_user = HTUser.new(userid: userid,
         email: @registration.applicant_email, displayname: @registration.applicant_name,
-        inst_id: @registration.inst_id, approver: @registration.auth_rep_email,
-        authorizer: authorizer, expire_type: @registration.expire_type,
+        inst_id: @registration.inst_id, identity_provider: institution.entityID,
+        approver: @registration.auth_rep_email, authorizer: authorizer,
+        expire_type: @registration.expire_type,
         expires: ExpirationDate.new(Time.zone.now, @registration.expire_type).default_extension_date,
         usertype: :external, access: :total, role: @registration.role)
-      institution = HTInstitution.find(@registration.inst_id)
       if institution.mfa?
         @ht_user.mfa = true
       else

--- a/app/lib/otis/registration_mover.rb
+++ b/app/lib/otis/registration_mover.rb
@@ -25,7 +25,7 @@ module Otis
       if institution.mfa?
         @ht_user.mfa = true
       else
-        @ht_user.iprestrict = @registration.ip_address
+        @ht_user.iprestrict = iprestrict
       end
       @ht_user.tap do |u|
         u.save
@@ -33,6 +33,10 @@ module Otis
     end
 
     private
+
+    def iprestrict
+      @registration.mfa_addendum.present? ? "any" : @registration.ip_address
+    end
 
     # For CAA users, hathitrust_authorizer should be present and we should use that.
     # auth_rep_email is the fallback.
@@ -51,12 +55,16 @@ module Otis
     # It can go away once we either:
     #   - have (non-downcased) REMOTE_USER for all user (otis captures this at registration & renewal)
     #   - can match any form of user id in other places
+    #
+    # Use safe dereference in the downcase call and blank default
+    # mainly for dev testing where registration.env may be empty.
+    # If that happens in production the save operation will fail but app won't crash.
     def userid
       if used_umich_idp?
         umich_uniqname
       else
         @registration.env["HTTP_X_REMOTE_USER"]
-      end.downcase
+      end&.downcase || ""
     end
 
     def umich_uniqname

--- a/app/models/ht_user.rb
+++ b/app/models/ht_user.rb
@@ -24,6 +24,7 @@ class HTUser < ApplicationRecord
   has_one :ht_count, foreign_key: :userid, primary_key: :userid
   has_many :ht_logs, -> { HTLog.ht_user }, foreign_key: :objid, primary_key: :email
   has_many :ht_approval_request, foreign_key: :userid, primary_key: :email
+  has_many :ht_registration, foreign_key: :applicant_email, primary_key: :email
 
   validates :iprestrict, presence: true, unless: :mfa
   validate :validate_iprestrict

--- a/test/registration_mover_test.rb
+++ b/test/registration_mover_test.rb
@@ -49,6 +49,16 @@ module Otis
       assert ht_user.iprestrict.nil?
       assert ht_user.mfa?
     end
+
+    test "finishing registration with non-MFA institution and MFA addendum uses iprestrict wildcard" do
+      non_mfa_inst = create(:ht_institution, shib_authncontext_class: nil)
+      mfa_addendum_registration = create(:ht_registration, mfa_addendum: true,
+        finished: Time.now, inst_id: non_mfa_inst.inst_id,
+        env: {"HTTP_X_REMOTE_USER" => fake_shib_id}.to_json)
+      ht_user = RegistrationMover.new(mfa_addendum_registration).ht_user
+      assert_equal ["any"], ht_user.iprestrict
+      refute ht_user.mfa?
+    end
   end
 
   class RegistrationMoverAuthorizerTest < ActiveSupport::TestCase

--- a/test/registration_mover_test.rb
+++ b/test/registration_mover_test.rb
@@ -79,4 +79,14 @@ module Otis
       assert_equal "authorizer@default.invalid", ht_user.authorizer
     end
   end
+
+  class RegistrationMoverInstitutionTest < ActiveSupport::TestCase
+    test "finishing registration uses institution.entityID to identity_provider" do
+      inst = create(:ht_institution)
+      registration = create(:ht_registration, inst_id: inst.inst_id,
+        env: {"HTTP_X_REMOTE_USER" => "nobody@default.invalid"}.to_json)
+      ht_user = RegistrationMover.new(registration).ht_user
+      assert_equal inst.entityID, ht_user.identity_provider
+    end
+  end
 end


### PR DESCRIPTION
- Create new user with MFA enabled if registration MFA Addendum is set.
- Check for existing registration with addendum when validating `ht_user.mfa`.
- Note that the latter depends on old registrations hanging around in order to license `ht_user.mfa` when it conflicts with our institution record.