### PR TITLE
DEV-351 OTIS ht_institutions.us display broken

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,5 +2,6 @@
 
 @import "bootstrap-sprockets";
 @import "bootstrap";
+@import "flag-icon";
 @import "otis";
 @import "users";

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -61,6 +61,7 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  # private network for docker
-  config.web_console.whitelisted_ips = "172.16.0.0/12"
+  # private networks for docker
+  # See https://stackoverflow.com/q/29417328
+  config.web_console.permissions = ["192.168.0.0/16", "172.16.0.0/12"]
 end


### PR DESCRIPTION
- Add reference to flag-icons-rails in app SCSS to restore US flag to ht_institutions.us.
- Replace deprecated config.web_console.whitelisted_ips (unrelated but necessary to do eventually).