### PR TITLE
DEV-319 Register IDP Change

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,8 +127,8 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faker (2.19.0)
-      i18n (>= 1.6, < 2)
+    faker (2.22.0)
+      i18n (>= 1.8.11, < 2)
     ffi (1.15.5)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
@@ -146,7 +146,7 @@ GEM
     http-cookie (1.0.4)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
-    i18n (1.10.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     i18n-tasks (0.9.37)
       activesupport (>= 4.0.2)
@@ -377,7 +377,6 @@ DEPENDENCIES
   rails (~> 6.1.6.1)
   rails-controller-testing
   rails-i18n (~> 6.0.0)
-  railties (~> 6.1.6.1)
   rubyzip (~> 2.0)
   sassc-rails
   selenium-webdriver
@@ -393,4 +392,4 @@ DEPENDENCIES
   whois-parser
 
 BUNDLED WITH
-   2.3.18
+   2.3.19

--- a/app/lib/otis/registration_mover.rb
+++ b/app/lib/otis/registration_mover.rb
@@ -10,9 +10,8 @@ module Otis
       return @ht_user unless @ht_user.nil?
 
       institution = HTInstitution.find(@registration.inst_id)
-      @ht_user = @registration.existing_user || HTUser.new
-      @ht_user = HTUser.new(userid: userid,
-        email: @registration.applicant_email, displayname: @registration.applicant_name,
+      @ht_user = @registration.existing_user || HTUser.new(email: @registration.applicant_email)
+      @ht_user.update(userid: userid, displayname: @registration.applicant_name,
         inst_id: @registration.inst_id, identity_provider: institution.entityID,
         approver: @registration.auth_rep_email, authorizer: authorizer,
         expire_type: @registration.expire_type,

--- a/app/lib/otis/registration_mover.rb
+++ b/app/lib/otis/registration_mover.rb
@@ -2,12 +2,6 @@ module Otis
   # Responsible for creating a new HTUser, populating it with the data in
   # an HTRegistration, and saving.
   class RegistrationMover
-    UMICH_IDP = "https://shibboleth.umich.edu/idp/shibboleth"
-
-    def self.user_exists?(registration)
-      HTUser.where(email: registration.applicant_email).exists?
-    end
-
     def initialize(registration)
       @registration = registration
     end
@@ -16,6 +10,7 @@ module Otis
       return @ht_user unless @ht_user.nil?
 
       institution = HTInstitution.find(@registration.inst_id)
+      @ht_user = @registration.existing_user || HTUser.new
       @ht_user = HTUser.new(userid: userid,
         email: @registration.applicant_email, displayname: @registration.applicant_name,
         inst_id: @registration.inst_id, identity_provider: institution.entityID,
@@ -81,7 +76,7 @@ module Otis
     end
 
     def used_umich_idp?
-      @registration.env["HTTP_X_SHIB_IDENTITY_PROVIDER"] == UMICH_IDP
+      @registration.env["HTTP_X_SHIB_IDENTITY_PROVIDER"] == Otis.config.umich_idp
     end
   end
 end

--- a/app/models/ht_registration.rb
+++ b/app/models/ht_registration.rb
@@ -84,6 +84,10 @@ class HTRegistration < ApplicationRecord
     end
   end
 
+  def existing_user
+    HTUser.where(email: applicant_email).first
+  end
+
   def resource_id
     id
   end

--- a/app/presenters/ht_registration_presenter.rb
+++ b/app/presenters/ht_registration_presenter.rb
@@ -25,7 +25,8 @@ class HTRegistrationPresenter < ApplicationPresenter
     received: Otis::Badge.new("activerecord.attributes.ht_registration.received", "label-default"),
     finished: Otis::Badge.new("activerecord.attributes.ht_registration.finished", "label-success"),
     institution_static_ip: Otis::Badge.new("activerecord.attributes.ht_registration.institution.static_ip", "label-danger"),
-    institution_mfa: Otis::Badge.new("activerecord.attributes.ht_registration.institution.mfa", "label-success")
+    institution_mfa: Otis::Badge.new("activerecord.attributes.ht_registration.institution.mfa", "label-success"),
+    existing_user: Otis::Badge.new("activerecord.attributes.ht_registration.email.existing_user", "label-warning")
   }.freeze
 
   def detail_fields
@@ -69,7 +70,8 @@ class HTRegistrationPresenter < ApplicationPresenter
   end
 
   def show_applicant_email
-    link_to applicant_email, "mailto:#{applicant_email}"
+    link_to(applicant_email, "mailto:#{applicant_email}") + " " +
+      (existing_user.present? ? BADGES[:existing_user].label_span : "")
   end
 
   def show_detail_display_name

--- a/app/views/ht_registrations/show.html.erb
+++ b/app/views/ht_registrations/show.html.erb
@@ -34,8 +34,9 @@
             data: { confirm: t(".confirm_delete", name: @registration.applicant_name) } %>
     <% end %>
 
-    <% if can?(:create, HTUser) && @registration.received? && !HTUser.exists?(@registration.applicant_email) %>
-      <%= link_to t(".create_user"), finish_ht_registration_path, method: :post, class: 'btn btn-success' %>
+    <% if can?(:create, HTUser) && @registration.received? && !@registration.finished? %>
+      <% link_name = @registration.existing_user.nil? ? t(".create_user") : t(".update_user") %>
+      <%= link_to link_name, finish_ht_registration_path, method: :post, class: 'btn btn-success' %>
     <% end %>
   <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,6 +62,8 @@ en:
         detail_identity_provider: Identity Provider
         detail_reverse_lookup: Reverse Lookup
         detail_scoped_affiliation: Scoped Affiliation
+        email:
+          existing_user: Existing User
         env: Authentication Data
         expire_type: Expire Type
         finished: Finished
@@ -292,12 +294,14 @@ en:
         staffdeveloper: Staff Developer
   ht_registrations:
     create:
-      duplicate: A user identified by "%{email}" already exists.
       success: Registration created for %{name}.
     destroy:
       success: Registration removed.
     edit:
       edit: Edit Registration
+    finish:
+      already_finished: Registration already completed.
+      success: Registration completed for %{name}.
     form:
       cancel: Cancel
       submit_changes: Submit Changes
@@ -321,6 +325,7 @@ en:
       edit: Edit
       email_preview: E-mail Preview
       login_details: Login Details
+      update_user: Update User
       whois_data: WHOIS Data
     update:
       success: Registration updated for %{name}.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -62,6 +62,8 @@ ja:
         detail_identity_provider: IDプロバイダー
         detail_reverse_lookup: 逆引き
         detail_scoped_affiliation: スコープ付き所属
+        email:
+          existing_user: 既存のユーザー
         env: 認証データ
         expire_type: 有効期限タイプ
         finished: 終了した
@@ -292,12 +294,14 @@ ja:
         staffdeveloper: スタッフ開発者
   ht_registrations:
     create:
-      duplicate: "「%{email}」というユーザーはすでに存在します。"
       success: "%{name}の登録が作成されました。"
     destroy:
       success: 登録が削除されました。
     edit:
       edit: 登録を編集する
+    finish:
+      already_finished: 登録はすでに完了しています。
+      success: "%{name}の登録が完了しました。"
     form:
       cancel: キャンセル
       submit_changes: 変更を送信する
@@ -321,6 +325,7 @@ ja:
       edit: 編集
       email_preview: Eメールプレビュー
       login_details: ログインの詳細
+      update_user: ユーザーを更新する
       whois_data: WHOISデータ
     update:
       success: "%{name}の登録が更新されました。"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,6 +10,8 @@ expires_soon_in_days: 30
 manager_email: manager@default.invalid
 reply_to_email: reply_to@default.invalid
 
+umich_idp: "https://shibboleth.umich.edu/idp/shibboleth"
+
 met_entity_endpoint: "https://met.refeds.org/met/entity"
 books_library_endpoint: "https://books.google.com/libraries"
 ht_login_test_endpoint: "https://babel.hathitrust.org/Shibboleth.sso/Login?target=https://babel.hathitrust.org/cgi/whoami"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     depends_on:
       - mariadb-dev
       - mariadb-test
-    command: bash -c "bin/init_dev_db.sh && bundle exec rails s -b 0.0.0.0"
+    command: bash -c "rm -f /usr/src/app/tmp/pids/server.pid && bin/init_dev_db.sh && bundle exec rails s -b 0.0.0.0"
 
   test:
     build: .

--- a/test/controllers/ht_registrations_controller_test.rb
+++ b/test/controllers/ht_registrations_controller_test.rb
@@ -231,13 +231,12 @@ class HTRegistrationsControllerCreateTest < ActionDispatch::IntegrationTest
     assert_not_empty flash[:alert]
   end
 
-  test "refuses to create registration for someone already in ht_users" do
-    user = FactoryBot.create(:ht_user)
-    params = attributes_for(:ht_registration, applicant_email: user.email)
+  test "allows creation of registration for someone already in ht_users" do
+    user = create(:ht_user)
+    params = attributes_for(:ht_registration, applicant_email: user.email, inst_id: user.inst_id)
     HTRegistration.delete_all
     post ht_registrations_url, params: {ht_registration: params}
-    assert_equal 0, HTRegistration.count
-    assert_match "already exists", flash[:alert]
+    assert_equal 1, HTRegistration.count
   end
 end
 
@@ -451,6 +450,7 @@ class HTRegistrationFinishTest < ActionDispatch::IntegrationTest
     post(finish_ht_registration_path(@received_registration))
     follow_redirect!
     post(finish_ht_registration_path(@received_registration))
+    follow_redirect!
     assert_not_empty flash[:alert]
   end
 end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -40,7 +40,7 @@ FactoryBot.define do
   end
 
   factory :ht_institution do
-    sequence(:inst_id) { |n| "#{n}#{Faker::Internet.domain_word}" }
+    sequence(:inst_id) { |n| "#{n}#{Faker::Internet.unique.domain_word}" }
     domain { Faker::Internet.domain_name }
     name { Faker::University.name }
     entityID { Faker::Internet.url }

--- a/test/registration_mover_test.rb
+++ b/test/registration_mover_test.rb
@@ -89,4 +89,16 @@ module Otis
       assert_equal inst.entityID, ht_user.identity_provider
     end
   end
+
+  class RegistrationMoverMergeTest < ActiveSupport::TestCase
+    test "finishing re-registration merges new fields onto existing user" do
+      old_inst = create(:ht_institution)
+      existing_user = create(:ht_user, inst_id: old_inst.inst_id)
+      new_inst = create(:ht_institution)
+      registration = create(:ht_registration, applicant_email: existing_user.email,
+        inst_id: new_inst.inst_id, env: {"HTTP_X_REMOTE_USER" => existing_user.email}.to_json)
+      new_user = RegistrationMover.new(registration).ht_user
+      assert_equal new_user, existing_user.reload
+    end
+  end
 end


### PR DESCRIPTION
*As a CAA user, I want to re-gain access when my identity as provided by my IdP has changed so that I can continue to use the service.*
- Allow HTRegistration to be created even if it shares an e-mail with an existing user.
  - Add localized "Existing User" badge to registration email field (on show page) as a warning that this is a re-registration.
- `RegistrationMover` updates existing users where appropriate instead of always creating anew.
- Condition availability of "Create User" (and new alternate "Update User") button on `finished` status of registration.
- Add a warning + no-op if the operator somehow manages to submit "Create/Update User" twice.
- QoL improvements for the devs
  - Remove that *gottverdammt* pid file when running `web` service.
  - Create some fake registrations with `env` values when seeding DB.
  - Update Faker gem for `Faker::Internet.base64` to produce high-quality Shib gobbledygook.
- HTInstitution factory seems to be able to produce `inst_id` collisions? Try to mitigate with `Faker...unique`.