### PR TITLE
DEV-438 update otis to use support@hathitrust.org

### DIFF
--- a/app/views/shared/_approval_request_body.html.erb
+++ b/app/views/shared/_approval_request_body.html.erb
@@ -17,6 +17,6 @@ information.<br/></p>
 
 <p>If you are no longer supervising the staff listed below or if you need to add
 or change staff with elevated access, please email
-<a href="mailto:feedback@issues.hathitrust.org">feedback@issues.hathitrust.org</a>.
+<a href="<%= Otis.config.support_email %>"><%= Otis.config.support_email %></a>.
 
 <p>Sincerely,<br/>HathiTrust User Support<br/></p>

--- a/app/views/shared/_approval_request_user_email.html.erb
+++ b/app/views/shared/_approval_request_user_email.html.erb
@@ -2,7 +2,7 @@
 <p>Your special access to in-copyright volumes in HathiTrust is scheduled to
 expire on <%= @user.expires_string %>. Renewal instructions have been sent to your
 approver at <%= @user.approver %>.</p>
-<p>Please contact us at <a href="mailto:feedback@issues.hathitrust.org">feedback@issues.hathitrust.org</a>
+<p>Please contact us at <a href="<%= Otis.config.support_email %>"><%= Otis.config.support_email %</a>
 if there are any issues with your renewal.</p>
 
 <p>Sincerely,<br/>HathiTrust User Support<br/></p>

--- a/app/views/shared/_registration_body.html.erb
+++ b/app/views/shared/_registration_body.html.erb
@@ -18,6 +18,6 @@ you can find instructions for using the service as well as demo videos at
 
 
 If you have any questions, please do not hesitate to contact us at
-<a mailto:"feedback@issues.hathitrust.org">feedback@issues.hathitrust.org</a>.</p>
+<a mailto:"<%= Otis.config.support_email %>"><%= Otis.config.support_email %></a>.</p>
 
 <p>Sincerely,<br/>HathiTrust User Support<br/></p>

--- a/app/views/user_mailer/approval_request_user_email.text.erb
+++ b/app/views/user_mailer/approval_request_user_email.text.erb
@@ -4,7 +4,7 @@ Your special access to in-copyright volumes in HathiTrust is scheduled to
 expire on <%= @user.expires_string %>. Renewal instructions have been sent to your
 approver at <%= @user.approver %>.
 
-Please contact us at feedback@issues.hathitrust.org
+Please contact us at <%= Otis.config.support_email %>
 if there are any issues with your renewal.
 
 Thank you,

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,6 +9,7 @@ expires_soon_in_days: 30
 
 manager_email: manager@default.invalid
 reply_to_email: reply_to@default.invalid
+support_email: support@hathitrust.org
 
 umich_idp: "https://shibboleth.umich.edu/idp/shibboleth"
 

--- a/test/system/ht_registrations_test.rb
+++ b/test/system/ht_registrations_test.rb
@@ -10,7 +10,7 @@ class HTRegistrationsTest < ApplicationSystemTestCase
   test "registration workflow" do
     # HT staff creates new registration
     visit_with_login ht_registrations_url
-    click_on "New Registration"
+    click_on "New Registration", match: :first
     assert_selector "h1", text: "New Registration"
     # HT staff enters user registration details
     fill_in "Applicant Name", with: "Test Registration Applicant"


### PR DESCRIPTION
- Move support email to settings and interpolate into templates.
- Fix system test with Capybara ambiguous element error.