### PR TITLE
DEV-448 OTIS system tests fail silently

### DIFF
--- a/bin/run_system_tests.sh
+++ b/bin/run_system_tests.sh
@@ -6,4 +6,5 @@ bin/wait-for mariadb-test:3306
 bin/wait-for chrome-server:4444
 bundle exec rake db:seed
 bundle exec rake test:system
+[ $? -eq 0 ] || exit $?
 bundle exec rake otis:clear_database RAILS_ENV=test

--- a/test/system/ht_approval_requests_test.rb
+++ b/test/system/ht_approval_requests_test.rb
@@ -21,7 +21,8 @@ class HTApprovalRequestsTest < ApplicationSystemTestCase
     # Show page
     # Extract approve URL from alert (only show in development/test environments)
     assert_selector "div.alert-success"
-    link = first("div.alert-success").text.match(/http.+/)[0]
+    # Success alert may have several URLs based on seeded data so we take the first one.
+    link = first("div.alert-success").text.split(', ')[0].match(/http.+/)[0]
 
     # Approver follows link from approval e-mail
     visit link


### PR DESCRIPTION
- Bail out of `bin/run_system_tests.sh` with nonzero exit status instead of running cleanup code.
- Fix approval request URL extraction in system tests when there are multiple URLs.