### PR TITLE
Add net-imap and net-pop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,10 @@ gem "jbuilder", "~> 2.5"
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.1.0", require: false
 
+# Removed as default gems in ruby 3.1
 gem "net-smtp"
+gem "net-pop"
+gem "net-imap"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,6 +205,10 @@ GEM
     msgpack (1.6.0)
     multipart-post (2.2.3)
     mysql2 (0.5.4)
+    net-imap (0.3.1)
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
     net-protocol (0.1.3)
       timeout
     net-smtp (0.3.3)
@@ -393,6 +397,8 @@ DEPENDENCIES
   loofah (~> 2.3, >= 2.3.1)
   maxmind-geoip2
   mysql2
+  net-imap
+  net-pop
   net-smtp
   pry
   pry-byebug (>= 3.9.0)


### PR DESCRIPTION
Didn't manifest as dependencies in development, but production failed to start. These were formerly included as core gems but aren't in ruby 3.1.