### PR TITLE
DEV-512 HTContact index fails if institution does not exist

### DIFF
--- a/app/presenters/ht_contact_presenter.rb
+++ b/app/presenters/ht_contact_presenter.rb
@@ -14,6 +14,8 @@ class HTContactPresenter < ApplicationPresenter
   end
 
   def show_inst_id
+    return "" if ht_institution.nil?
+
     link_to ht_institution.name, ht_institution_path(ht_institution)
   end
 

--- a/test/presenters/ht_contact_presenter_test.rb
+++ b/test/presenters/ht_contact_presenter_test.rb
@@ -34,6 +34,13 @@ class HTContactPresenterTest < ActiveSupport::TestCase
     assert_match "ht_institutions/", @contact.field_value(:inst_id)
   end
 
+  # Test a degenerate case seen in production database
+  test "#field_value :inst_id displays as blank if institution does not exist" do
+    bad_contact = HTContactPresenter.new(create(:ht_contact, ht_contact_type: @type))
+    bad_contact.inst_id = "not_a_valid_inst_id"
+    assert_equal "", bad_contact.field_value(:inst_id)
+  end
+
   test "#field_value :contact_type displays as link" do
     assert_match "ht_contact_types/", @contact.field_value(:contact_type)
   end


### PR DESCRIPTION
- This is a situation encountered in production: contact with inst_id "laurentian" does not correspond to an ht_institution.
- This has been tested in staging as part of another branch (`cp_not_prepared_err`)