### PR TITLE
TTO-10 Sequel Downgrade

### DIFF
--- a/.github/workflows/manual-deploy-staging.yml
+++ b/.github/workflows/manual-deploy-staging.yml
@@ -1,5 +1,5 @@
 ---
-name: Manual Deploy to Testing
+name: Manual Deploy to Staging
 
 on:
   workflow_dispatch:
@@ -27,7 +27,7 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
-    environment: testing
+    environment: staging
     steps:
       - name: Clone latest repository
         uses: actions/checkout@v3
@@ -38,7 +38,7 @@ jobs:
         uses: hathitrust/github_actions/validate-tag@v1
         with:
           tag: ${{ github.event.inputs.tag }}
-      - name: Deploy to testing
+      - name: Deploy to staging
         uses: mlibrary/deploy-to-kubernetes@v3
         with:
           registry_token: ${{ github.token }}

--- a/Gemfile
+++ b/Gemfile
@@ -101,6 +101,9 @@ gem "checkpoint"
 gem "mysql2"
 gem "dotenv-rails"
 
+# Freeze Sequel version number because of Checkpoint prepared statement issues
+gem "sequel", "5.52.0"
+
 group :development, :test do
   gem "byebug"
   gem "standard"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,7 +308,7 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sequel (5.62.0)
+    sequel (5.52.0)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -409,6 +409,7 @@ DEPENDENCIES
   rubyzip (~> 2.0)
   sassc-rails
   selenium-webdriver
+  sequel (= 5.52.0)
   simplecov
   simplecov-lcov
   sqlite3


### PR DESCRIPTION
- Downgrade Sequel to version prior to Ruby 3.1 upgrade.
- Add manual release to staging action
- Incorporate fix to release to testing action (upon which the above is obviously based)