### PR TITLE
TTO-66 ssdproxy users should have access=normal

### DIFF
--- a/app/lib/otis/registration_mover.rb
+++ b/app/lib/otis/registration_mover.rb
@@ -16,7 +16,7 @@ module Otis
         approver: @registration.auth_rep_email, authorizer: authorizer,
         expire_type: @registration.expire_type,
         expires: ExpirationDate.new(Time.zone.now, @registration.expire_type).default_extension_date,
-        usertype: :external, access: :total, role: @registration.role)
+        usertype: :external, access: access, role: @registration.role)
       if institution.mfa?
         @ht_user.mfa = true
       else
@@ -28,6 +28,11 @@ module Otis
     end
 
     private
+
+    # ssdproxy role grants normal access, all other roles grant total access
+    def access
+      @registration.role == "ssdproxy" ? "normal" : "total"
+    end
 
     def iprestrict
       @registration.mfa_addendum.present? ? "any" : @registration.ip_address

--- a/test/registration_mover_test.rb
+++ b/test/registration_mover_test.rb
@@ -105,4 +105,28 @@ module Otis
       assert_equal "corrections", new_user.role
     end
   end
+
+  class RegistrationMoverAccessTest < ActiveSupport::TestCase
+    test "finalized ssdproxy user has normal access" do
+      registration = create(:ht_registration, received: Time.now,
+        ip_address: Faker::Internet.public_ip_v4_address,
+        role: :ssdproxy,
+        env: {"HTTP_X_REMOTE_USER" => "https://shibboleth.umich.edu/idp/shibboleth!http://www.hathitrust.org/shibboleth-sp!gobbledygook"}
+        .to_json)
+      ht_user = RegistrationMover.new(registration).ht_user
+      assert_equal "normal", ht_user.access
+    end
+
+    test "finalized non-ssdproxy user has total access" do
+      (HTUser::ROLES - [:ssdproxy]).each do |role|
+        registration = create(:ht_registration, received: Time.now,
+          ip_address: Faker::Internet.public_ip_v4_address,
+          role: role,
+          env: {"HTTP_X_REMOTE_USER" => fake_shib_id}
+          .to_json)
+        ht_user = RegistrationMover.new(registration).ht_user
+        assert_equal "total", ht_user.access
+      end
+    end
+  end
 end


### PR DESCRIPTION
- `RegistrationMover` grants access "normal" to ssdproxy registrations and "total" otherwise.
- Would like confirmation from the reviewer that the business logic is sound.