### PR TITLE
DEV-1019 Move ht_institutions cron job to OTIS

### DIFF
--- a/app/lib/otis/institutions_export.rb
+++ b/app/lib/otis/institutions_export.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Used by DailyDigestMailer to report on action items requiring attention from
+# administrator.
+module Otis
+  class InstitutionsExport
+    attr_reader :institutions
+    def initialize
+      @institutions = HTInstitution.all.order(:inst_id)
+    end
+
+    # Returns a String with each line being "inst_id <TAB> name"
+    def instid_data
+      @instid_data ||= institutions.map { |i| "#{i.inst_id}\t#{i.name}" }.join("\n")
+    end
+
+    # Returns a String with each line being "entity_id <TAB> name"
+    def entityid_data
+      @entityid_data ||= institutions.map { |i| "#{i.entityID}\t#{i.name}" }.join("\n")
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,6 +19,12 @@ ht_login_test_endpoint: "https://babel.hathitrust.org/Shibboleth.sso/Login?targe
 
 geoip_path: "/usr/src/app/vendor/geoip/GeoIP2-City-Test.mmdb"
 
+# Institution export files
+ht_institutions_file: "ht_institutions_test.tsv"
+ht_saml_entity_ids_file: "ht_saml_entity_ids_test.tsv"
+# Where institutions_export cron job ultimately deposits these files.
+export_files_directory: "/usr/src/app/public/"
+
 jira:
   site: https://hathitrust.atlassian.net/
   context_path: ""

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -20,8 +20,8 @@ ht_login_test_endpoint: "https://babel.hathitrust.org/Shibboleth.sso/Login?targe
 geoip_path: "/usr/src/app/vendor/geoip/GeoIP2-City-Test.mmdb"
 
 # Institution export files
-ht_institutions_file: "ht_institutions_test.tsv"
-ht_saml_entity_ids_file: "ht_saml_entity_ids_test.tsv"
+ht_institutions_file: "ht_institutions.tsv"
+ht_saml_entity_ids_file: "ht_saml_entity_ids.tsv"
 # Where institutions_export cron job ultimately deposits these files.
 export_files_directory: "/usr/src/app/public/"
 

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -10,3 +10,5 @@ checkpoint:
     url: <%= ENV['DB_URL'] %>
 
 relative_url_root: <%= ENV['RAILS_RELATIVE_URL_ROOT'] %>
+
+export_files_directory: <%= ENV['EXPORT_FILES_DIRECTORY'] %>

--- a/lib/tasks/institutions_export.rake
+++ b/lib/tasks/institutions_export.rake
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+namespace :otis do
+  desc <<~DESC
+    Creates ht_institutions.tsv (inst_id -> name)
+    and ht_saml_entity_ids.tsv (entityID -> name)
+    and copies them to Otis.config.export_files_directory
+    (public/ for the purposes of testing and development,
+    see config/settings.yml).
+  DESC
+  task institutions_export: :environment do
+    ie = Otis::InstitutionsExport.new
+    Dir.mktmpdir do |d|
+      ht_institutions_temp = File.join(d, Otis.config.ht_institutions_file)
+      ht_saml_entity_ids_temp = File.join(d, Otis.config.ht_saml_entity_ids_file)
+      File.write(ht_institutions_temp, ie.instid_data)
+      File.write(ht_saml_entity_ids_temp, ie.entityid_data)
+      FileUtils.cp(ht_institutions_temp, Otis.config.export_files_directory)
+      FileUtils.cp(ht_saml_entity_ids_temp, Otis.config.export_files_directory)
+    end
+  end
+end

--- a/test/institutions_export_test.rb
+++ b/test/institutions_export_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Otis
+  class InstitutionsExportTest < ActiveSupport::TestCase
+    test "create functional InstitutionsExport" do
+      ie = InstitutionsExport.new
+      assert_not_nil ie
+      assert_not_nil ie.institutions
+    end
+  end
+end

--- a/test/lib/tasks/daily_digest_task_test.rb
+++ b/test/lib/tasks/daily_digest_task_test.rb
@@ -13,10 +13,6 @@ module Otis
       end
     end
 
-    def setup
-      Application.load_tasks
-    end
-
     test "task runs without errors" do
       Rake::Task["otis:send_daily_digest"].invoke
     end

--- a/test/lib/tasks/institutions_export_task_test.rb
+++ b/test/lib/tasks/institutions_export_task_test.rb
@@ -6,7 +6,9 @@ module Otis
   class InstitutionsExportTaskTest < ActiveSupport::TestCase
     def setup
       remove_generated_files
-      create(:ht_institution)
+      5.times do
+        create(:ht_institution)
+      end
     end
 
     def teardown
@@ -33,9 +35,13 @@ module Otis
     test "task writes the expected files" do
       Rake::Task["otis:institutions_export"].invoke
       assert File.exist? ht_institutions_file
-      assert File.size(ht_institutions_file).positive?
       assert File.exist? ht_saml_entity_ids_file
-      assert File.size(ht_saml_entity_ids_file).positive?
+      ht_institutions_file_content = File.read(ht_institutions_file)
+      ht_saml_entity_ids_file_content = File.read(ht_saml_entity_ids_file)
+      HTInstitution.find_each do |inst|
+        assert ht_institutions_file_content.include? [inst.inst_id, inst.name].join("\t")
+        assert ht_saml_entity_ids_file_content.include? [inst.entityID, inst.name].join("\t")
+      end
     end
   end
 end

--- a/test/lib/tasks/institutions_export_task_test.rb
+++ b/test/lib/tasks/institutions_export_task_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Otis
+  class InstitutionsExportTaskTest < ActiveSupport::TestCase
+    def setup
+      remove_generated_files
+      create(:ht_institution)
+    end
+
+    def teardown
+      remove_generated_files
+    end
+
+    def remove_generated_files
+      if File.exist? ht_institutions_file
+        FileUtils.rm ht_institutions_file
+      end
+      if File.exist? ht_saml_entity_ids_file
+        FileUtils.rm ht_saml_entity_ids_file
+      end
+    end
+
+    def ht_institutions_file
+      File.join(Otis.config.export_files_directory, Otis.config.ht_institutions_file)
+    end
+
+    def ht_saml_entity_ids_file
+      File.join(Otis.config.export_files_directory, Otis.config.ht_saml_entity_ids_file)
+    end
+
+    test "task writes the expected files" do
+      Rake::Task["otis:institutions_export"].invoke
+      assert File.exist? ht_institutions_file
+      assert File.size(ht_institutions_file).positive?
+      assert File.exist? ht_saml_entity_ids_file
+      assert File.size(ht_saml_entity_ids_file).positive?
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -60,6 +60,8 @@ end
 Keycard::DB.migrate!
 Checkpoint::DB.migrate!
 
+# Loading them here seems to keep individual rake tests from clobbering coverage stats.
+Otis::Application.load_tasks
 load File.expand_path("lib/tasks/migrate_users.rake", Rails.root)
 Rake::Task.define_task(:environment)
 Rake::Task["otis:migrate_users"].invoke


### PR DESCRIPTION
- Add `InstitutionsExport` class and rake task that invokes it.
- Add three config values:
  - `ht_institutions_file`
  - `ht_saml_entity_ids_file`
  - `export_files_directory`
    - `ht_tanka` is setting `EXPORT_FILES_DIRECTORY` to `/htapps/www/files/tmp/` temporarily, for evaluation.
- Maintenance:
  - Annoying name collision fixed: rename `test/lib/tasks/daily_digest_test.rb` to `daily_digest_task_test.rb`
  - Call `Otis::Application.load_tasks` in test helper to keep rake tests from clobbering each other's coverage