### PR TITLE
DEV-1019 Move ht_institutions cron job to OTIS (fixes)

### DIFF
--- a/app/lib/otis/institutions_export.rb
+++ b/app/lib/otis/institutions_export.rb
@@ -4,19 +4,22 @@
 # administrator.
 module Otis
   class InstitutionsExport
-    attr_reader :institutions
+    attr_reader :enabled_institutions, :enabled_for_login_institutions
     def initialize
-      @institutions = HTInstitution.all.order(:inst_id)
+      @enabled_institutions = HTInstitution.where.not(enabled: 0).order(:inst_id)
+      @enabled_for_login_institutions = HTInstitution.enabled.order(:inst_id)
     end
 
     # Returns a String with each line being "inst_id <TAB> name"
+    # Includes all institutions but those with enabled=0
     def instid_data
-      @instid_data ||= institutions.map { |i| "#{i.inst_id}\t#{i.name}" }.join("\n")
+      @instid_data ||= enabled_institutions.map { |i| "#{i.inst_id}\t#{i.name}" }.join("\n")
     end
 
     # Returns a String with each line being "entity_id <TAB> name"
+    # Only includes institutions with enabled=1 (excludes social login and private)
     def entityid_data
-      @entityid_data ||= institutions.map { |i| "#{i.entityID}\t#{i.name}" }.join("\n")
+      @entityid_data ||= enabled_for_login_institutions.map { |i| "#{i.entityID}\t#{i.name}" }.join("\n")
     end
   end
 end

--- a/lib/tasks/institutions_export.rake
+++ b/lib/tasks/institutions_export.rake
@@ -13,8 +13,8 @@ namespace :otis do
     Dir.mktmpdir do |d|
       ht_institutions_temp = File.join(d, Otis.config.ht_institutions_file)
       ht_saml_entity_ids_temp = File.join(d, Otis.config.ht_saml_entity_ids_file)
-      File.write(ht_institutions_temp, ie.instid_data)
-      File.write(ht_saml_entity_ids_temp, ie.entityid_data)
+      File.write(ht_institutions_temp, ie.instid_data + "\n")
+      File.write(ht_saml_entity_ids_temp, ie.entityid_data + "\n")
       FileUtils.cp(ht_institutions_temp, Otis.config.export_files_directory)
       FileUtils.cp(ht_saml_entity_ids_temp, Otis.config.export_files_directory)
     end

--- a/test/institutions_export_test.rb
+++ b/test/institutions_export_test.rb
@@ -7,7 +7,8 @@ module Otis
     test "create functional InstitutionsExport" do
       ie = InstitutionsExport.new
       assert_not_nil ie
-      assert_not_nil ie.institutions
+      assert_not_nil ie.enabled_institutions
+      assert_not_nil ie.enabled_for_login_institutions
     end
   end
 end


### PR DESCRIPTION
- Neither export file should contain institutions with enabled=0
- SAML entities file should contain only enabled=1 institutions
- Add tests for correct number of entries in export files
- Add trailing newline to both export files