### PR TITLE
TTO-246 Alert to Update CKE Editor in OTIS

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
       ettin (~> 1.1)
       sequel (~> 5.6)
     childprocess (4.1.0)
-    ckeditor (5.1.1)
+    ckeditor (5.1.3)
       orm_adapter (~> 0.5.0)
     coderay (1.1.3)
     coffee-rails (4.2.2)

--- a/app/views/ht_approval_requests/edit.html.erb
+++ b/app/views/ht_approval_requests/edit.html.erb
@@ -1,6 +1,7 @@
 <%= javascript_include_tag Ckeditor.cdn_url %>
 <script>
   CKEDITOR.config.language = "<%= I18n.locale %>";
+  CKEDITOR.config.versionCheck = false;
 </script>
 
 <div id="maincontent" class="row">

--- a/app/views/ht_registrations/preview.html.erb
+++ b/app/views/ht_registrations/preview.html.erb
@@ -1,6 +1,7 @@
 <%= javascript_include_tag Ckeditor.cdn_url %>
 <script>
   CKEDITOR.config.language = "<%= I18n.locale %>";
+  CKEDITOR.config.versionCheck = false;
 </script>
 
 <div id="maincontent" class="row">

--- a/config/initializers/ckeditor.rb
+++ b/config/initializers/ckeditor.rb
@@ -1,4 +1,4 @@
 Ckeditor.setup do |config|
   # //cdn.ckeditor.com/<version.number>/<distribution>/ckeditor.js
-  config.cdn_url = "//cdn.ckeditor.com/4.17.1/basic/ckeditor.js"
+  config.cdn_url = "//cdn.ckeditor.com/4.22.1/basic/ckeditor.js"
 end


### PR DESCRIPTION
- Update to latest open-source version of CKEditor 4 and latest gem.
- Set `CKEDITOR.config.versionCheck = false;` to suppress chatty warnings.
- Note: CKEditor 4 has been EOL for a year, see https://github.com/hathitrust/otis/issues/225