### PR TITLE
DEV-1241 SSD Proxy Reports from PT

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,6 +92,8 @@ gem "flag-icons-rails"
 gem "rails-i18n", "~> 6.0.0"
 gem "maxmind-geoip2"
 gem "jira-ruby"
+gem "ransack"
+gem "kaminari"
 
 gem "canister"
 gem "ettin"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,6 +181,18 @@ GEM
       thor (>= 0.14, < 2.0)
     json (2.6.2)
     jwt (2.5.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -280,6 +292,10 @@ GEM
       thor (~> 1.0)
     rainbow (3.1.1)
     rake (13.1.0)
+    ransack (4.2.1)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
+      i18n
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -405,6 +421,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jira-ruby
   jquery-rails
+  kaminari
   keycard!
   listen (>= 3.0.5, < 3.2)
   loofah (~> 2.19)
@@ -421,6 +438,7 @@ DEPENDENCIES
   rails (~> 6.1.7.7)
   rails-controller-testing
   rails-i18n (~> 6.0.0)
+  ransack
   rubyzip (~> 2.0)
   sassc-rails
   selenium-webdriver

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Contacts
 Contact Types
 Logs
 Registrations                 # for new users
+SSD Proxy Reports
 ```
 
 Most pages have the standard CRU(D) operations (not a lot of Deletes), Rails style.
@@ -129,9 +130,13 @@ Most pages have the standard CRU(D) operations (not a lot of Deletes), Rails sty
 ## Design
 
 There is very little branding, since it is not at all facing the public.
-There has been some adjustments to improve color contrast.
+There have been some adjustments to improve color contrast.
 Otis uses `select2.org` JavaScript library to make searchable lists of items (users, institutions).
 Also uses `Ckeditor` for rich text editing used in composing emails.
+
+All index pages use Bootstrap Table (https://bootstrap-table.com) for data display. SSD Proxy Reports
+has advanced search features server-side using Ransack (https://github.com/activerecord-hackery/ransack).
+This approach is expected to be a model for updating the other index pages.
 
 ## Functionality
 

--- a/app/controllers/ht_ssd_proxy_reports_controller.rb
+++ b/app/controllers/ht_ssd_proxy_reports_controller.rb
@@ -13,10 +13,4 @@ class HTSSDProxyReportsController < ApplicationController
   def presenter(report)
     HTSSDProxyReportPresenter.new(report, controller: self, action: params[:action].to_sym)
   end
-
-  def report_params(permitted_fields)
-    @report_params ||= params.require(:ht_ssd_proxy_report)
-      .permit(*permitted_fields)
-      .transform_values! { |v| v.present? ? v : nil }
-  end
 end

--- a/app/controllers/ht_ssd_proxy_reports_controller.rb
+++ b/app/controllers/ht_ssd_proxy_reports_controller.rb
@@ -21,8 +21,10 @@ class HTSSDProxyReportsController < ApplicationController
   # The `filter` keys come from HTSSDProxyReportPresenter::ALL_FIELDS which combines relevant
   # columns from the three associated database tables.
 
-  # Used by `#matchers` to translate `filter` keys into an Array that the `#ransack` method
-  # can apply to the Active Record query.
+  # Used by `#matchers` to translate `filter` keys into values that the `#ransack` method
+  # can apply to the Active Record query. Many of these (the text input ones)
+  # are of the form `*_i_cont` which is a case-insensitive contains equivalent to "LIKE '%value%'".
+  # Those selectable by a dropdown menu can use an equality (`_eq`)  matcher.
   RANSACK_MATCHERS = {
     "author" => :ht_hathifile_author_i_cont,
     "bib_num" => :ht_hathifile_bib_num_cont,

--- a/app/controllers/ht_ssd_proxy_reports_controller.rb
+++ b/app/controllers/ht_ssd_proxy_reports_controller.rb
@@ -77,7 +77,7 @@ class HTSSDProxyReportsController < ApplicationController
 
   # @return [Hash] value to be returned to Bootstrap Table as JSON
   def json_query
-    # Create a Ransack::Search
+    # Create a Ransack::Search with all of the filter fields translated into Ransack matchers.
     search = HTSSDProxyReport.includes(:ht_hathifile, :ht_institution)
       .ransack(matchers)
     # Apply the sort field and order, or default if not provided.

--- a/app/controllers/ht_ssd_proxy_reports_controller.rb
+++ b/app/controllers/ht_ssd_proxy_reports_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class HTSSDProxyReportsController < ApplicationController
+  def index
+    reports = HTSSDProxyReport.order(:datetime)
+    @reports = reports.map { |r| presenter r }
+  end
+
+  private
+
+  def presenter(report)
+    HTSSDProxyReportPresenter.new(report, controller: self, action: params[:action].to_sym)
+  end
+
+  def report_params(permitted_fields)
+    @report_params ||= params.require(:ht_ssd_proxy_report)
+      .permit(*permitted_fields)
+      .transform_values! { |v| v.present? ? v : nil }
+  end
+end

--- a/app/controllers/ht_ssd_proxy_reports_controller.rb
+++ b/app/controllers/ht_ssd_proxy_reports_controller.rb
@@ -4,6 +4,8 @@ class HTSSDProxyReportsController < ApplicationController
   def index
     reports = HTSSDProxyReport.order(:datetime)
     @reports = reports.map { |r| presenter r }
+    @time_start = HTSSDProxyReport.minimum(:datetime).to_date.to_s
+    @time_end = HTSSDProxyReport.maximum(:datetime).to_date.to_s
   end
 
   private

--- a/app/controllers/ht_ssd_proxy_reports_controller.rb
+++ b/app/controllers/ht_ssd_proxy_reports_controller.rb
@@ -1,16 +1,101 @@
 # frozen_string_literal: true
 
 class HTSSDProxyReportsController < ApplicationController
+  RANSACK_MATCHERS = {
+    "author" => :ht_hathifile_author_i_cont,
+    "bib_num" => :ht_hathifile_bib_num_cont,
+    "content_provider_code" => :ht_hathifile_content_provider_code_eq,
+    "datetime" => :datetime_start,
+    "digitization_agent_code" => :ht_hathifile_digitization_agent_code,
+    "email" => :email_i_cont,
+    "htid" => :htid_i_cont,
+    "imprint" => :ht_hathifile_imprint_i_cont,
+    "inst_code" => :inst_code_eq,
+    "institution_name" => :ht_institution_name_i_cont,
+    "rights_code" => :ht_hathifile_rights_code_eq,
+    "rights_date_used" => :ht_hathifile_rights_date_used_eq,
+    "title" => :ht_hathifile_title_i_cont
+  }
+
+  RANSACK_ORDER = {
+    "author" => :ht_hathifile_author,
+    "bib_num" => :ht_hathifile_bib_num,
+    "content_provider_code" => :ht_hathifile_content_provider_code,
+    "datetime" => :datetime,
+    "digitization_agent_code" => :ht_hathifile_digitization_agent_code,
+    "email" => :email,
+    "htid" => :htid,
+    "imprint" => :ht_hathifile_imprint,
+    "inst_code" => :inst_code,
+    "institution_name" => :ht_institution_name,
+    "rights_code" => :ht_hathifile_rights_code,
+    "rights_date_used" => :ht_hathifile_rights_date_used,
+    "title" => :ht_hathifile_title
+  }
+
   def index
-    reports = HTSSDProxyReport.order(:datetime)
-    @reports = reports.map { |r| presenter r }
-    @time_start = HTSSDProxyReport.minimum(:datetime).to_date.to_s
-    @time_end = HTSSDProxyReport.maximum(:datetime).to_date.to_s
+    respond_to do |format|
+      format.html do
+        @time_start = HTSSDProxyReport.minimum(:datetime).to_date.to_s
+        @time_end = HTSSDProxyReport.maximum(:datetime).to_date.to_s
+      end
+      format.json do
+        render json: json_query
+      end
+    end
   end
 
   private
 
   def presenter(report)
     HTSSDProxyReportPresenter.new(report, controller: self, action: params[:action].to_sym)
+  end
+
+  def json_query
+    search = HTSSDProxyReport.includes(:ht_hathifile, :ht_institution)
+      .ransack(matchers)
+    sort_name = RANSACK_ORDER.fetch(params[:sortName], "datetime")
+    sort_order = params.fetch(:sortOrder, "asc")
+    # Ransack requires lower case sort direction.
+    search.sorts = "#{sort_name} #{sort_order.downcase}"
+    result = search.result
+    if params[:pageNumber] && params[:pageSize]
+      result = result.page(params[:pageNumber]).per(params[:pageSize])
+    end
+    {
+      total: result.count,
+      totalNotFiltered: HTSSDProxyReport.count,
+      rows: result.map { |line| report_to_json line }
+    }
+  end
+
+  # Use presenter to translate HTSSDProxyReport into JSON hash
+  def report_to_json(report)
+    report = presenter report
+    HTSSDProxyReportPresenter::ALL_FIELDS.to_h do |field|
+      [field, report.field_value(field)]
+    end
+  end
+
+  # Filter param sent by Bootstrap Table translated into Hash
+  def filter
+    @filter ||= JSON.parse(params.fetch("filter", "{}"))
+  end
+
+  # Translate Bootstrap Table filter fields and date start/end fields
+  # into Ransack matchers
+  def matchers
+    return @matchers if @matchers
+
+    @matchers = filter.transform_keys do |key|
+      RANSACK_MATCHERS.fetch(key, key)
+    end
+    if params[:d1]
+      @matchers[:datetime_gteq] = params[:d1]
+    end
+    if params[:d2]
+      @matchers[:datetime_lteq] = params[:d2]
+    end
+    @matchers
   end
 end

--- a/app/controllers/ht_ssd_proxy_reports_controller.rb
+++ b/app/controllers/ht_ssd_proxy_reports_controller.rb
@@ -59,11 +59,12 @@ class HTSSDProxyReportsController < ApplicationController
     # Ransack requires lower case sort direction.
     search.sorts = "#{sort_name} #{sort_order.downcase}"
     result = search.result
+    total = result.count
     if params[:pageNumber] && params[:pageSize]
       result = result.page(params[:pageNumber]).per(params[:pageSize])
     end
     {
-      total: result.count,
+      total: total,
       totalNotFiltered: HTSSDProxyReport.count,
       rows: result.map { |line| report_to_json line }
     }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,7 +2,7 @@
 
 module ApplicationHelper
   def nav_menu
-    %w[users approval_requests institutions contacts contact_types logs registrations]
+    %w[users approval_requests institutions contacts contact_types logs registrations ssd_proxy_reports]
       .select { |item| can?(:index, "ht_#{item}") }
       .map { |item| {item: item, path: send("ht_#{item}_path")} }
   end

--- a/app/models/ht_hathifile.rb
+++ b/app/models/ht_hathifile.rb
@@ -4,4 +4,25 @@
 # Only fleshed out to the extent needed. There's a lot we could do here.
 class HTHathifile < ApplicationRecord
   self.table_name = "hathifiles.hf"
+  self.primary_key = "htid"
+  has_many :ht_ssd_proxy_report, foreign_key: :htid, primary_key: :htid
+
+  # SSD Proxy Reports uses Ransack gem to search by association
+  def self.ransackable_attributes(auth_object = nil)
+    %w[
+      author bib_num content_provider_code digitization_agent_code htid imprint
+      rights_code rights_date_used title
+    ]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    %w[ht_ssd_proxy_report]
+  end
+
+  private
+
+  # Ransack search matchers assume string values, so convert this integer
+  ransacker :bib_num do
+    Arel.sql("CONVERT(#{table_name}.bib_num, CHAR(9))")
+  end
 end

--- a/app/models/ht_hathifile.rb
+++ b/app/models/ht_hathifile.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Used as a secondary source of information for SSD Proxy Reports
+# Only fleshed out to the extent needed. There's a lot we could do here.
+class HTHathifile < ApplicationRecord
+  self.table_name = "hathifiles.hf"
+end

--- a/app/models/ht_institution.rb
+++ b/app/models/ht_institution.rb
@@ -16,6 +16,11 @@ class HTInstitution < ApplicationRecord
 
   before_save :set_defaults
 
+  # SSD Proxy Reports uses Ransack gem to search by association
+  def self.ransackable_attributes(auth_object = nil)
+    %w[inst_id name]
+  end
+
   # https://stackoverflow.com/a/57485464
   attribute :enabled, ActiveRecord::Type::Integer.new
 

--- a/app/models/ht_ssd_proxy_report.rb
+++ b/app/models/ht_ssd_proxy_report.rb
@@ -3,14 +3,31 @@
 # Only used read-only in Otis for reporting
 class HTSSDProxyReport < ApplicationRecord
   self.table_name = "ht_web.reports_downloads_ssdproxy"
-  default_scope { order(:datetime) }
-  belongs_to :ht_hathifile, foreign_key: :htid, primary_key: :htid
+  # default_scope { order(:datetime) }
+  has_one :ht_hathifile, foreign_key: :htid, primary_key: :htid
+  has_one :ht_institution, foreign_key: :inst_id, primary_key: :inst_code
+
+  def self.ransackable_attributes(auth_object = nil)
+    ["datetime", "email", "htid", "id", "in_copyright", "inst_code", "is_partial", "sha", "yyyy", "yyyymm"]
+  end
+
+  def self.ransackable_associations(auth_object = nil)
+    ["ht_hathifile", "ht_institution"]
+  end
 
   def institution_name
-    @institution_name ||= HTInstitution.where(inst_id: inst_code)&.first&.name
+    institution&.name
+  end
+
+  def institution
+    ht_institution
   end
 
   def hf
-    @hf = ht_hathifile || HTHathifile.new(htid: htid)
+    ht_hathifile
+  end
+
+  ransacker :datetime do
+    Arel.sql("DATE(#{table_name}.datetime)")
   end
 end

--- a/app/models/ht_ssd_proxy_report.rb
+++ b/app/models/ht_ssd_proxy_report.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Only used read-only in Otis for reporting
+class HTSSDProxyReport < ApplicationRecord
+  self.table_name = "ht_web.reports_downloads_ssdproxy"
+  default_scope { order(:datetime) }
+  belongs_to :ht_hathifile, foreign_key: :htid, primary_key: :htid
+
+  def institution_name
+    @institution_name ||= HTInstitution.where(inst_id: inst_code)&.first&.name
+  end
+
+  def hf
+    @hf = ht_hathifile
+  end
+end

--- a/app/models/ht_ssd_proxy_report.rb
+++ b/app/models/ht_ssd_proxy_report.rb
@@ -11,6 +11,6 @@ class HTSSDProxyReport < ApplicationRecord
   end
 
   def hf
-    @hf = ht_hathifile
+    @hf = ht_hathifile || HTHathifile.new(htid: htid)
   end
 end

--- a/app/presenters/ht_ssd_proxy_report_presenter.rb
+++ b/app/presenters/ht_ssd_proxy_report_presenter.rb
@@ -63,6 +63,8 @@ class HTSSDProxyReportPresenter < ApplicationPresenter
   # Could also define these on the model.
   HF_FIELDS.each do |field|
     define_method("show_#{field}") do
+      return "" if hf.nil?
+
       hf.send field
     end
   end

--- a/app/presenters/ht_ssd_proxy_report_presenter.rb
+++ b/app/presenters/ht_ssd_proxy_report_presenter.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+class HTSSDProxyReportPresenter < ApplicationPresenter
+  ALL_FIELDS = %i[
+    datetime
+    htid
+    bib_num
+    rights_code
+    email
+    inst_code
+    institution_name
+    content_provider_code
+    digitization_agent_code
+    title
+    imprint
+    author
+    rights_date_used
+  ].freeze
+
+  DATA_FILTER_CONTROLS = {
+    datetime: :datepicker,
+    htid: :input,
+    bib_num: :input,
+    rights_code: :select,
+    email: :input,
+    inst_code: :select,
+    institution_name: :select,
+    content_provider_code: :select,
+    digitization_agent_code: :select,
+    title: :input,
+    imprint: :input,
+    author: :input,
+    rights_date_used: :select
+  }.freeze
+
+  def self.data_filter_control(field)
+    DATA_FILTER_CONTROLS[field].to_s
+  end
+
+  private
+
+  def show_author
+    hf.author
+  end
+
+  def show_datetime
+    datetime.to_formatted_s(:db)
+  end
+
+  def show_email
+    link_to email, ht_user_path(email)
+  end
+
+  def show_bib_num
+    hf.bib_num
+  end
+
+  def show_content_provider_code
+    hf.content_provider_code
+  end
+
+  def show_digitization_agent_code
+    hf.digitization_agent_code
+  end
+
+  def show_imprint
+    hf.imprint
+  end
+
+  def show_institution_name
+    return "" if institution_name.nil?
+
+    link_to institution_name, ht_institution_path(inst_code)
+  end
+
+  def show_rights_code
+    hf.rights_code
+  end
+
+  def show_rights_date_used
+    hf.rights_date_used
+  end
+
+  def show_title
+    hf.title
+  end
+end

--- a/app/presenters/ht_ssd_proxy_report_presenter.rb
+++ b/app/presenters/ht_ssd_proxy_report_presenter.rb
@@ -48,6 +48,17 @@ class HTSSDProxyReportPresenter < ApplicationPresenter
     DATA_FILTER_CONTROLS[field].to_s
   end
 
+  def self.header_class(field)
+    case field
+    when :title, :imprint
+      "min--250"
+    when :author
+      "min--150"
+    else
+      ""
+    end
+  end
+
   # Dynamically create simple #show_X methods for each hf column we display in the index.
   # Could also define these on the model.
   HF_FIELDS.each do |field|

--- a/app/presenters/ht_ssd_proxy_report_presenter.rb
+++ b/app/presenters/ht_ssd_proxy_report_presenter.rb
@@ -20,7 +20,7 @@ class HTSSDProxyReportPresenter < ApplicationPresenter
 
   # Type of filter control to specify for a given column.
   DATA_FILTER_CONTROLS = {
-    datetime: :datepicker,
+    datetime: :input,
     htid: :input,
     bib_num: :input,
     rights_code: :select,
@@ -81,7 +81,7 @@ class HTSSDProxyReportPresenter < ApplicationPresenter
   # we would ever get a 404 since we don't typically jettison users or institutions.
 
   def show_datetime
-    datetime.to_formatted_s(:db)
+    "<span class=\"text-nowrap\">#{datetime.to_formatted_s(:db)}</span"
   end
 
   def show_email

--- a/app/presenters/ht_ssd_proxy_report_presenter.rb
+++ b/app/presenters/ht_ssd_proxy_report_presenter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class HTSSDProxyReportPresenter < ApplicationPresenter
+  # All the columns in the index page.
   ALL_FIELDS = %i[
     datetime
     htid
@@ -17,6 +18,7 @@ class HTSSDProxyReportPresenter < ApplicationPresenter
     rights_date_used
   ].freeze
 
+  # Type of filter control to specify for a given column.
   DATA_FILTER_CONTROLS = {
     datetime: :datepicker,
     htid: :input,
@@ -33,6 +35,7 @@ class HTSSDProxyReportPresenter < ApplicationPresenter
     rights_date_used: :select
   }.freeze
 
+  # Used below to create accessor methods for the relevant hathifiles.hf fields.
   HF_FIELDS = %i[
     author
     bib_num
@@ -48,6 +51,8 @@ class HTSSDProxyReportPresenter < ApplicationPresenter
     DATA_FILTER_CONTROLS[field].to_s
   end
 
+  # Some CSS in index.html.erb allows the title, imprint, and author fields to be a bit wider
+  # than the default.
   def self.header_class(field)
     case field
     when :title, :imprint
@@ -70,6 +75,10 @@ class HTSSDProxyReportPresenter < ApplicationPresenter
   end
 
   private
+
+  # More or less standard `show_X` methods when we want to customize the display.
+  # We could check the `link_to` targets to make sure they actually exist, but it's unlikely
+  # we would ever get a 404 since we don't typically jettison users or institutions.
 
   def show_datetime
     datetime.to_formatted_s(:db)

--- a/app/presenters/ht_ssd_proxy_report_presenter.rb
+++ b/app/presenters/ht_ssd_proxy_report_presenter.rb
@@ -33,15 +33,30 @@ class HTSSDProxyReportPresenter < ApplicationPresenter
     rights_date_used: :select
   }.freeze
 
+  HF_FIELDS = %i[
+    author
+    bib_num
+    content_provider_code
+    digitization_agent_code
+    imprint
+    rights_code
+    rights_date_used
+    title
+  ].freeze
+
   def self.data_filter_control(field)
     DATA_FILTER_CONTROLS[field].to_s
   end
 
-  private
-
-  def show_author
-    hf.author
+  # Dynamically create simple #show_X methods for each hf column we display in the index.
+  # Could also define these on the model.
+  HF_FIELDS.each do |field|
+    define_method("show_#{field}") do
+      hf.send field
+    end
   end
+
+  private
 
   def show_datetime
     datetime.to_formatted_s(:db)
@@ -51,37 +66,9 @@ class HTSSDProxyReportPresenter < ApplicationPresenter
     link_to email, ht_user_path(email)
   end
 
-  def show_bib_num
-    hf.bib_num
-  end
-
-  def show_content_provider_code
-    hf.content_provider_code
-  end
-
-  def show_digitization_agent_code
-    hf.digitization_agent_code
-  end
-
-  def show_imprint
-    hf.imprint
-  end
-
   def show_institution_name
     return "" if institution_name.nil?
 
     link_to institution_name, ht_institution_path(inst_code)
-  end
-
-  def show_rights_code
-    hf.rights_code
-  end
-
-  def show_rights_date_used
-    hf.rights_date_used
-  end
-
-  def show_title
-    hf.title
   end
 end

--- a/app/views/ht_ssd_proxy_reports/index.html.erb
+++ b/app/views/ht_ssd_proxy_reports/index.html.erb
@@ -1,0 +1,65 @@
+<div id="maincontent" class="row">
+
+  <h2><%= t ".ht_ssd_proxy_reports" %></h2>
+
+  <div class="row">
+    <div class="report-toolbar" id="toolbar">
+      <form class="form-inline" id="form-daterange-filter">
+        <div class="form-group">
+          <label for="d1 d2">(DOES NOT WORK YET) Filter between </label>
+          <input class="form-control" type="text" size="11" value="0000-00-00" name="datetime-start" id="d1" />
+          <span style="margin-left: 0.5rem"> - </span>
+          <input class="form-control"  type="text" size="11" value="9999-99-99" name="datetime-end" id="d2" />
+        </div>
+        <button class="btn btn-default" id="action-datetime-filter">Filter</button>
+        <button class="btn btn-default" id="action-clear-datetime-filter" type="button" name="clearDateFilter" title="Clear date filters"><i class="glyphicon glyphicon-trash"></i> </button>
+      </form>
+      <button type="submit" class="btn btn-primary hidden" id="action-copy">Copy</button>
+    </div>
+  </div>
+
+  <div class="row">
+    <% fields = HTSSDProxyReportPresenter::ALL_FIELDS %>
+    <table id="contact_types"
+      class="table table-striped"
+      data-filter-control="true"
+      data-filter-control-multiple-search="true"
+      data-filter-default=""
+      data-pagination="true"
+      data-pagination-v-align="both"
+      data-search="true"
+      data-show-columns="true"
+      data-show-search-clear-button="true"
+      data-show-filter-control-switch="true"
+      data-sort-select-options="true"
+      data-toggle="table"
+      data-toolbar="#toolbar"
+    >
+      <thead class="thead-dark">    
+        <tr>
+          <% fields.each do |field| %>
+            <% control = HTSSDProxyReportPresenter.data_filter_control(field) %>
+            <th data-field="<%= field %>"
+              data-filter-control="<%= control %>"
+              data-sortable="true"
+              <% if control == "datepicker" %>
+              data-filter-starts-with-search="true"
+              <% end %>
+            >
+              <%= HTSSDProxyReportPresenter.field_label field %>
+            </th>
+          <% end %>
+        </tr>
+      </thead>
+  
+      <% @reports.each do |c| %>
+        <tr>
+          <% fields.each do |field| %>
+            <td><%= c.field_value field %></td>
+          <% end %>
+        </tr>
+      <% end %>
+    </table>
+  </div>
+</div>
+

--- a/app/views/ht_ssd_proxy_reports/index.html.erb
+++ b/app/views/ht_ssd_proxy_reports/index.html.erb
@@ -6,6 +6,7 @@
   function clearDateRangeFilter() {
     $('#date-start').val("<%= @date_start %>");
     $('#date-end').val("<%= @date_end %>");
+    $('#table').bootstrapTable('clearFilterControl')
     $('#table').bootstrapTable('refresh')
   }
 

--- a/app/views/ht_ssd_proxy_reports/index.html.erb
+++ b/app/views/ht_ssd_proxy_reports/index.html.erb
@@ -1,27 +1,88 @@
+<script>
+  function applyDateRangeFilter() {
+    var $table = $('#table');
+    var d1 = $('#d1').val();
+    var d2 = $('#d2').val();
+    $table.bootstrapTable('filterBy', {}, {
+      'filterAlgorithm': (row, filters) => {
+        return row.datetime >= d1 && row.datetime <= d2;
+      }
+    });
+  }
+
+  function clearDateRangeFilter() {
+    var $table = $('#table');
+    $table.bootstrapTable('filterBy', {}, {
+      'filterAlgorithm': (row, filters) => {
+        return true;
+      }
+    });
+  }
+</script>
+
+<style type="text/css">
+  .report-toolbar {
+    /*margin: 1rem 0;*/
+    display: flex;
+    justify-content: space-between;
+    max-width: 90vw;
+  }
+
+  td.nowrap {
+    white-space: nowrap;
+  }
+
+  td.min--350 {
+    min-width: 350px;
+  }
+  td.min--250 {
+    min-width: 250px;
+  }
+
+  /* Show/hide column control menu items */
+  .dropdown-item-marker {
+    white-space:nowrap;
+  }
+
+  .bootstrap-table .fixed-table-container .table thead th {
+    vertical-align: top;
+  }
+</style>
+
 <div id="maincontent" class="row">
 
   <h2><%= t ".ht_ssd_proxy_reports" %></h2>
 
   <div class="row">
     <div class="report-toolbar" id="toolbar">
-      <form class="form-inline" id="form-daterange-filter">
+      <div class="form-inline" id="form-daterange-filter">
         <div class="form-group">
-          <label for="d1 d2">(DOES NOT WORK YET) Filter between </label>
-          <input class="form-control" type="text" size="11" value="0000-00-00" name="datetime-start" id="d1" />
+          <label for="d1 d2"><%= t ".date_range" %> </label>
+          <input class="form-control" type="text" size="11" value="<%= @time_start %>" name="time-start" id="d1" />
           <span style="margin-left: 0.5rem"> - </span>
-          <input class="form-control"  type="text" size="11" value="9999-99-99" name="datetime-end" id="d2" />
+          <input class="form-control" type="text" size="11" value="<%= @time_end %>" name="time-end" id="d2" />
         </div>
-        <button class="btn btn-default" id="action-datetime-filter">Filter</button>
-        <button class="btn btn-default" id="action-clear-datetime-filter" type="button" name="clearDateFilter" title="Clear date filters"><i class="glyphicon glyphicon-trash"></i> </button>
-      </form>
-      <button type="submit" class="btn btn-primary hidden" id="action-copy">Copy</button>
+        <button class="btn btn-default"
+          id="action-datetime-filter"
+          onclick="applyDateRangeFilter();"
+        >
+          <%= t ".filter" %>
+        </button>
+        <button class="btn btn-default"
+          id="action-clear-datetime-filter"
+          onclick="clearDateRangeFilter();"
+          title="<%= t ".clear_filter" %>"
+        >
+          <i class="glyphicon glyphicon-trash"></i>
+        </button>
+      </div>
     </div>
   </div>
 
   <div class="row">
     <% fields = HTSSDProxyReportPresenter::ALL_FIELDS %>
-    <table id="contact_types"
-      class="table table-striped"
+    <table id="table"
+      class="table table-striped table-bordered table-hover table-condensed"
       data-filter-control="true"
       data-filter-control-multiple-search="true"
       data-filter-default=""
@@ -29,8 +90,10 @@
       data-pagination-v-align="both"
       data-search="true"
       data-show-columns="true"
-      data-show-search-clear-button="true"
+      data-show-export="true"
+      data-show-extended-pagination="true"
       data-show-filter-control-switch="true"
+      data-show-search-clear-button="true"
       data-sort-select-options="true"
       data-toggle="table"
       data-toolbar="#toolbar"
@@ -42,8 +105,9 @@
             <th data-field="<%= field %>"
               data-filter-control="<%= control %>"
               data-sortable="true"
+              data-tableexport-value="<%= field.to_s.titleize %>"
               <% if control == "datepicker" %>
-              data-filter-starts-with-search="true"
+                data-filter-starts-with-search="true"
               <% end %>
             >
               <%= HTSSDProxyReportPresenter.field_label field %>
@@ -55,7 +119,15 @@
       <% @reports.each do |c| %>
         <tr>
           <% fields.each do |field| %>
-            <td><%= c.field_value field %></td>
+            <td
+              <% if [:title, :imprint].include? field %>
+                class="min--350"
+              <% elsif [:institution_name, :author].include? field %>
+                class="min--250"
+              <% end %>
+            >
+              <%= c.field_value field %>
+            </td>
           <% end %>
         </tr>
       <% end %>

--- a/app/views/ht_ssd_proxy_reports/index.html.erb
+++ b/app/views/ht_ssd_proxy_reports/index.html.erb
@@ -1,22 +1,20 @@
 <script>
   function applyDateRangeFilter() {
-    var $table = $('#table');
-    var d1 = $('#d1').val();
-    var d2 = $('#d2').val();
-    $table.bootstrapTable('filterBy', {}, {
-      'filterAlgorithm': (row, filters) => {
-        return row.datetime >= d1 && row.datetime <= d2;
-      }
-    });
+    $('#table').bootstrapTable('refresh')
   }
 
   function clearDateRangeFilter() {
-    var $table = $('#table');
-    $table.bootstrapTable('filterBy', {}, {
-      'filterAlgorithm': (row, filters) => {
-        return true;
-      }
-    });
+    $('#d1').val("<%= @time_start %>");
+    $('#d2').val("<%= @time_end %>");
+    $('#table').bootstrapTable('refresh')
+  }
+
+  function queryParams(params) {
+    var d1 = $('#d1').val();
+    var d2 = $('#d2').val();
+    params.d1 = d1;
+    params.d2 = d2;
+    return params
   }
 </script>
 
@@ -28,15 +26,11 @@
     max-width: 90vw;
   }
 
-  td.nowrap {
-    white-space: nowrap;
-  }
-
-  td.min--350 {
-    min-width: 350px;
-  }
-  td.min--250 {
+  .min--250 {
     min-width: 250px;
+  }
+  .min--150 {
+    min-width: 150px;
   }
 
   /* Show/hide column control menu items */
@@ -58,9 +52,23 @@
       <div class="form-inline" id="form-daterange-filter">
         <div class="form-group">
           <label for="d1 d2"><%= t ".date_range" %> </label>
-          <input class="form-control" type="text" size="11" value="<%= @time_start %>" name="time-start" id="d1" />
+          <input class="form-control"
+            type="text"
+            size="11"
+            value="<%= @time_start %>"
+            name="time-start"
+            id="d1"
+            onchange="applyDateRangeFilter();"
+          />
           <span style="margin-left: 0.5rem"> - </span>
-          <input class="form-control" type="text" size="11" value="<%= @time_end %>" name="time-end" id="d2" />
+          <input class="form-control"
+            type="text"
+            size="11"
+            value="<%= @time_end %>"
+            name="time-end"
+            id="d2"
+            onchange="applyDateRangeFilter();"
+          />
         </div>
         <button class="btn btn-default"
           id="action-datetime-filter"
@@ -80,57 +88,47 @@
   </div>
 
   <div class="row">
-    <% fields = HTSSDProxyReportPresenter::ALL_FIELDS %>
     <table id="table"
       class="table table-striped table-bordered table-hover table-condensed"
+      data-export-data-type="all"
+      data-export-options='{"fileName": "SSDProxyReport"}'
+      data-export-types="['json', 'xml', 'csv', 'excel']"
       data-filter-control="true"
       data-filter-control-multiple-search="true"
       data-filter-default=""
       data-pagination="true"
       data-pagination-v-align="both"
-      data-search="true"
+      data-query-params="queryParams"
+      data-query-params-type=""
+      data-search="false"
       data-show-columns="true"
       data-show-export="true"
       data-show-extended-pagination="true"
       data-show-filter-control-switch="true"
-      data-show-search-clear-button="true"
+      data-show-search-clear-button="false"
+      data-side-pagination="server"
       data-sort-select-options="true"
       data-toggle="table"
       data-toolbar="#toolbar"
+      data-url="ht_ssd_proxy_reports?format=json"
     >
       <thead class="thead-dark">    
         <tr>
+          <% fields = HTSSDProxyReportPresenter::ALL_FIELDS %>
           <% fields.each do |field| %>
             <% control = HTSSDProxyReportPresenter.data_filter_control(field) %>
+            <% th_class = HTSSDProxyReportPresenter.header_class(field) %>
             <th data-field="<%= field %>"
+              class="<%= th_class %>"
               data-filter-control="<%= control %>"
               data-sortable="true"
               data-tableexport-value="<%= field.to_s.titleize %>"
-              <% if control == "datepicker" %>
-                data-filter-starts-with-search="true"
-              <% end %>
             >
               <%= HTSSDProxyReportPresenter.field_label field %>
             </th>
           <% end %>
         </tr>
       </thead>
-  
-      <% @reports.each do |c| %>
-        <tr>
-          <% fields.each do |field| %>
-            <td
-              <% if [:title, :imprint].include? field %>
-                class="min--350"
-              <% elsif [:institution_name, :author].include? field %>
-                class="min--250"
-              <% end %>
-            >
-              <%= c.field_value field %>
-            </td>
-          <% end %>
-        </tr>
-      <% end %>
     </table>
   </div>
 </div>

--- a/app/views/ht_ssd_proxy_reports/index.html.erb
+++ b/app/views/ht_ssd_proxy_reports/index.html.erb
@@ -51,7 +51,7 @@
 
 <div id="maincontent" class="row">
 
-  <h2><%= t ".ht_ssd_proxy_reports" %></h2>
+  <h1><%= t ".ht_ssd_proxy_reports" %></h1>
 
   <div class="row">
     <div class="report-toolbar" id="toolbar">

--- a/app/views/ht_ssd_proxy_reports/index.html.erb
+++ b/app/views/ht_ssd_proxy_reports/index.html.erb
@@ -4,16 +4,14 @@
   }
 
   function clearDateRangeFilter() {
-    $('#d1').val("<%= @time_start %>");
-    $('#d2').val("<%= @time_end %>");
+    $('#date-start').val("<%= @date_start %>");
+    $('#date-end').val("<%= @date_end %>");
     $('#table').bootstrapTable('refresh')
   }
 
   function queryParams(params) {
-    var d1 = $('#d1').val();
-    var d2 = $('#d2').val();
-    params.d1 = d1;
-    params.d2 = d2;
+    params.dateStart = $('#date-start').val();
+    params.dateEnd = $('#date-end').val();
     return params
   }
 </script>
@@ -51,22 +49,22 @@
     <div class="report-toolbar" id="toolbar">
       <div class="form-inline" id="form-daterange-filter">
         <div class="form-group">
-          <label for="d1 d2"><%= t ".date_range" %> </label>
+          <label for="date-start date-end"><%= t ".date_range" %> </label>
           <input class="form-control"
             type="text"
             size="11"
-            value="<%= @time_start %>"
-            name="time-start"
-            id="d1"
+            value="<%= @date_start %>"
+            name="date-start"
+            id="date-start"
             onchange="applyDateRangeFilter();"
           />
           <span style="margin-left: 0.5rem"> - </span>
           <input class="form-control"
             type="text"
             size="11"
-            value="<%= @time_end %>"
-            name="time-end"
-            id="d2"
+            value="<%= @date_end %>"
+            name="date-end"
+            id="date-end"
             onchange="applyDateRangeFilter();"
           />
         </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,8 +15,8 @@
       <%= javascript_include_tag "https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/i18n/#{locale.to_s}.js" %>
     <% end %>
     <%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" %>
-    <%= stylesheet_link_tag("https://unpkg.com/bootstrap-table@1.23.2/dist/extensions/filter-control/bootstrap-table-filter-control.css") %>
-    <%= stylesheet_link_tag("https://unpkg.com/bootstrap-table@1.23.2/dist/bootstrap-table.min.css") %>
+    <%= stylesheet_link_tag("https://unpkg.com/bootstrap-table@1.23.4/dist/extensions/filter-control/bootstrap-table-filter-control.css") %>
+    <%= stylesheet_link_tag("https://unpkg.com/bootstrap-table@1.23.4/dist/bootstrap-table.min.css") %>
 
     <% # Keyboard-related overrides that trigger when a bootstrap-table search  %>
     <% # field has focus.                                                       %>
@@ -45,12 +45,12 @@
     </script>
     <% # Uses bootstrap-table  %>
     <script src="https://cdn.jsdelivr.net/npm/tableexport.jquery.plugin@1.30.0/tableExport.min.js"></script>
-    <script src="https://unpkg.com/bootstrap-table@1.23.2/dist/bootstrap-table.min.js"></script>
-    <script src="https://unpkg.com/bootstrap-table@1.23.2/dist/extensions/filter-control/bootstrap-table-filter-control.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap-table@1.23.2/dist/extensions/export/bootstrap-table-export.min.js"></script>
+    <script src="https://unpkg.com/bootstrap-table@1.23.4/dist/bootstrap-table.min.js"></script>
+    <script src="https://unpkg.com/bootstrap-table@1.23.4/dist/extensions/filter-control/bootstrap-table-filter-control.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap-table@1.23.4/dist/extensions/export/bootstrap-table-export.min.js"></script>
     <% locale_map = {"ja" => "ja-JP"} %>
     <% if locale_map[I18n.locale.to_s].present? %>
-      <script src="https://unpkg.com/bootstrap-table@1.23.2/dist/locale/bootstrap-table-<%= locale_map[I18n.locale.to_s] %>.min.js"></script>
+      <script src="https://unpkg.com/bootstrap-table@1.23.4/dist/locale/bootstrap-table-<%= locale_map[I18n.locale.to_s] %>.min.js"></script>
     <% end %>
   </head>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,8 +15,8 @@
       <%= javascript_include_tag "https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/i18n/#{locale.to_s}.js" %>
     <% end %>
     <%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" %>
-
-    <%= stylesheet_link_tag("https://unpkg.com/bootstrap-table@1.18.3/dist/bootstrap-table.min.css") %>
+    <%= stylesheet_link_tag("https://unpkg.com/bootstrap-table@1.23.2/dist/extensions/filter-control/bootstrap-table-filter-control.css") %>
+    <%= stylesheet_link_tag("https://unpkg.com/bootstrap-table@1.23.2/dist/bootstrap-table.min.css") %>
 
     <% # Keyboard-related overrides that trigger when a bootstrap-table search  %>
     <% # field has focus.                                                       %>
@@ -43,6 +43,13 @@
         }
       });
     </script>
+    <% # Uses bootstrap-table  %>
+    <script src="https://unpkg.com/bootstrap-table@1.23.2/dist/bootstrap-table.min.js"></script>
+    <script src="https://unpkg.com/bootstrap-table@1.23.2/dist/extensions/filter-control/bootstrap-table-filter-control.min.js"></script>
+    <% locale_map = {"ja" => "ja-JP"} %>
+    <% if locale_map[I18n.locale.to_s].present? %>
+      <script src="https://unpkg.com/bootstrap-table@1.23.2/dist/locale/bootstrap-table-<%= locale_map[I18n.locale.to_s] %>.min.js"></script>
+    <% end %>
   </head>
 
   <body>
@@ -51,12 +58,6 @@
         <%= render 'shared/flash_message' %>
       <%= yield %>
     </div>
-    <% # Uses bootstrap-table  %>
-    <script src="https://unpkg.com/bootstrap-table@1.18.3/dist/bootstrap-table.min.js"></script>
-    <% locale_map = {"ja" => "ja-JP"} %>
-    <% if locale_map[I18n.locale].present? %>
-      <script src="https://unpkg.com/bootstrap-table@1.18.3/dist/locale/bootstrap-table-<%= locale_map[I18n.locale] %>.min.js"></script>
-    <% end %>
     <script>
        // Add aria-label to bootstrap-table search box.
        // Doesn't silence warnings about lack of visible label, however.

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -44,8 +44,10 @@
       });
     </script>
     <% # Uses bootstrap-table  %>
+    <script src="https://cdn.jsdelivr.net/npm/tableexport.jquery.plugin@1.30.0/tableExport.min.js"></script>
     <script src="https://unpkg.com/bootstrap-table@1.23.2/dist/bootstrap-table.min.js"></script>
     <script src="https://unpkg.com/bootstrap-table@1.23.2/dist/extensions/filter-control/bootstrap-table-filter-control.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap-table@1.23.2/dist/extensions/export/bootstrap-table-export.min.js"></script>
     <% locale_map = {"ja" => "ja-JP"} %>
     <% if locale_map[I18n.locale.to_s].present? %>
       <script src="https://unpkg.com/bootstrap-table@1.23.2/dist/locale/bootstrap-table-<%= locale_map[I18n.locale.to_s] %>.min.js"></script>

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -20,4 +20,5 @@ ActiveSupport::Inflector.inflections do |inflect|
   inflect.acronym "HT"
   inflect.acronym "IP"
   inflect.acronym "SAML"
+  inflect.acronym "SSD"
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -350,6 +350,9 @@ en:
       success: Registration updated for %{name}.
   ht_ssd_proxy_reports:
     index:
+      clear_filter: Clear filters
+      date_range: Date Range
+      filter: Filter
       ht_ssd_proxy_reports: SSD Proxy Reports
   ht_user:
     badges:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,6 +84,20 @@ en:
         sent: Sent
         status: Status
         usertype: User Type
+      ht_ssd_proxy_report:
+        author: Author
+        bib_num: Bib Number
+        content_provider_code: Content Provider
+        datetime: Time
+        digitization_agent_code: Digitization Agent
+        email: E-mail
+        htid: HTID
+        imprint: Imprint
+        inst_code: Institution Code
+        institution_name: Institution Name
+        rights_code: Rights Code
+        rights_date_used: Rights Date
+        title: Title
       ht_user:
         access: Access
         accesses: Accesses
@@ -163,6 +177,7 @@ en:
       institutions: Institutions
       logs: Logs
       registrations: Registrations
+      ssd_proxy_reports: SSD Proxy Reports
       users: Users
     not_logged_in: Not Logged In
   ht_approval_request:
@@ -333,6 +348,9 @@ en:
       whois_data: WHOIS Data
     update:
       success: Registration updated for %{name}.
+  ht_ssd_proxy_reports:
+    index:
+      ht_ssd_proxy_reports: SSD Proxy Reports
   ht_user:
     badges:
       expired: Expired

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -84,6 +84,20 @@ ja:
         sent: 送信された
         status: 状態
         usertype: ユーザータイプ
+      ht_ssd_proxy_report:
+        author: 著者
+        bib_num: 書誌番号
+        content_provider_code: コンテンツプロバイダー
+        datetime: 時間
+        digitization_agent_code: デジタル化エージェント
+        email: Eメール
+        htid: HTID
+        imprint: 奥付
+        inst_code: 機関コード
+        institution_name: 機関名
+        rights_code: 著作権コード
+        rights_date_used: 著作権の日付
+        title: タイトル
       ht_user:
         access: アクセス
         accesses: アクセス数
@@ -163,6 +177,7 @@ ja:
       institutions: 機関
       logs: ログ
       registrations: 登録
+      ssd_proxy_reports: SSD Proxy 報告
       users: ユーザー
     not_logged_in: ログインしていない
   ht_approval_request:
@@ -333,6 +348,9 @@ ja:
       whois_data: WHOISデータ
     update:
       success: "%{name}の登録が更新されました。"
+  ht_ssd_proxy_reports:
+    index:
+      ht_ssd_proxy_reports: SSD Proxy 報告
   ht_user:
     badges:
       expired: 期限切れ

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -350,6 +350,9 @@ ja:
       success: "%{name}の登録が更新されました。"
   ht_ssd_proxy_reports:
     index:
+      clear_filter: フィルターをクリアする
+      date_range: 日付範囲
+      filter: フィルタリングする
       ht_ssd_proxy_reports: SSD Proxy 報告
   ht_user:
     badges:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,10 @@ Rails.application.routes.draw do
     resources :ht_contact_types
   end
 
+  scope format: false, constraints: {id: /.+/} do
+    resources :ht_ssd_proxy_reports
+  end
+
   scope constraints: {id: /.+/} do
     resources :ht_logs
   end

--- a/db/ht_web.sql
+++ b/db/ht_web.sql
@@ -1,2 +1,5 @@
 CREATE DATABASE ht_web;
 GRANT ALL on ht_web.* to 'otis';
+
+CREATE DATABASE hathifiles;
+GRANT ALL on hathifiles.* to 'otis';

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -120,6 +120,63 @@ ActiveRecord::Schema.define(version: 0) do # rubocop:disable Metrics/BlockLength
     t.boolean :auth_requested, default: false
   end
 
+# MariaDB [ht_web]> describe reports_downloads_ssdproxy;
+# +--------------+------------------+------+-----+---------+----------------+
+# | Field        | Type             | Null | Key | Default | Extra          |
+# +--------------+------------------+------+-----+---------+----------------+
+# | id           | int(11) unsigned | NO   | PRI | NULL    | auto_increment |
+# | in_copyright | int(1)           | YES  |     | NULL    |                |
+# | yyyy         | int(11)          | NO   | MUL | NULL    |                |
+# | yyyymm       | varchar(20)      | NO   |     |         |                |
+# | datetime     | datetime         | NO   | MUL | NULL    |                |
+# | htid         | varchar(255)     | NO   | MUL |         |                |
+# | is_partial   | int(1)           | YES  |     | 0       |                |
+# | email        | varchar(255)     | NO   |     |         |                |
+# | inst_code    | varchar(255)     | YES  | MUL | NULL    |                |
+# | sha          | binary(20)       | YES  | MUL | NULL    |                |
+# +--------------+------------------+------+-----+---------+----------------+
+
+  create_table "ht_web.reports_downloads_ssdproxy", if_not_exists: true do |t|
+    t.boolean :in_copyright
+    t.integer :yyyy, default: 0
+    t.string :yyyymm
+    t.timestamp :datetime
+    t.string :htid
+    t.boolean :is_partial
+    t.string :email
+    t.string :inst_code
+    t.binary :sha
+  end
+
+  create_table "hathifiles.hf", id: false, if_not_exists: true do |t|
+    t.string :htid, null: false
+    t.boolean :access
+    t.string :rights_code
+    t.bigint :bib_num
+    t.string :description
+    t.string :source
+    t.string :source_bib_num
+    t.string :oclc
+    t.string :isbn
+    t.string :issn
+    t.string :lccn
+    t.string :title
+    t.string :imprint
+    t.string :rights_reason
+    t.timestamp :rights_timestamp
+    t.boolean :us_gov_doc_flag
+    t.integer :rights_date_used
+    t.string :pub_place
+    t.string :lang_code
+    t.string :bib_fmt
+    t.string :collection_code
+    t.string :content_provider_code
+    t.string :responsible_entity_code
+    t.string :digitization_agent_code
+    t.string :access_profile_code
+    t.string :author
+  end
+
   create_table :ht_billing_members, id: false do |t|
     t.string :inst_id, primary_key: true
     t.string :parent_inst_id

--- a/lib/tasks/clear_database.rake
+++ b/lib/tasks/clear_database.rake
@@ -15,5 +15,7 @@ namespace :otis do
     ActiveRecord::Base.connection.execute("DELETE FROM ht_web.otis_approval_requests")
     ActiveRecord::Base.connection.execute("DELETE FROM ht_web.otis_logs")
     ActiveRecord::Base.connection.execute("DELETE FROM ht_web.otis_registrations")
+    ActiveRecord::Base.connection.execute("DELETE FROM ht_web.reports_downloads_ssdproxy")
+    ActiveRecord::Base.connection.execute("DELETE FROM hathifiles.hf")
   end
 end

--- a/test/controllers/ht_ssd_proxy_reports_controller_test.rb
+++ b/test/controllers/ht_ssd_proxy_reports_controller_test.rb
@@ -12,8 +12,8 @@ class HTSSDProxyReportControllerTest < ActionDispatch::IntegrationTest
     sign_in!
     get ht_ssd_proxy_reports_url
     assert_response :success
-    assert_not_nil assigns(:time_start)
-    assert_not_nil assigns(:time_end)
+    assert_not_nil assigns(:date_start)
+    assert_not_nil assigns(:date_end)
     assert_equal "index", @controller.action_name
     assert_match "SSD Proxy Reports", @response.body
   end

--- a/test/controllers/ht_ssd_proxy_reports_controller_test.rb
+++ b/test/controllers/ht_ssd_proxy_reports_controller_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class HTSSDProxyReportControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    10.times { create(:ht_ssd_proxy_report) }
+  end
+
+  test "should get index" do
+    sign_in!
+    get ht_ssd_proxy_reports_url
+    assert_response :success
+    assert_not_nil assigns(:reports)
+    assert_not_nil assigns(:time_start)
+    assert_not_nil assigns(:time_end)
+    assert_equal "index", @controller.action_name
+    assert_match "SSD Proxy Reports", @response.body
+  end
+end
+
+# class HTLogsControllerJSONTest < ActionDispatch::IntegrationTest
+#   def setup
+#     4.times { create(:ht_log) }
+#   end
+# 
+#   test "export list of all logs as JSON" do
+#     sign_in!
+#     get ht_logs_url format: :json
+#     HTLog.all.each do |log|
+#       assert_match log.objid, @response.body
+#     end
+#     assert_kind_of Array, JSON.parse(@response.body)
+#   end
+# end

--- a/test/controllers/ht_ssd_proxy_reports_controller_test.rb
+++ b/test/controllers/ht_ssd_proxy_reports_controller_test.rb
@@ -4,6 +4,7 @@ require "test_helper"
 
 class HTSSDProxyReportControllerTest < ActionDispatch::IntegrationTest
   def setup
+    HTSSDProxyReport.delete_all
     10.times { create(:ht_ssd_proxy_report) }
   end
 
@@ -19,6 +20,7 @@ class HTSSDProxyReportControllerTest < ActionDispatch::IntegrationTest
 
   class HTSSDProxyReportControllerJSONTest < ActionDispatch::IntegrationTest
     def setup
+      HTSSDProxyReport.delete_all
       10.times { create(:ht_ssd_proxy_report) }
     end
 

--- a/test/controllers/ht_ssd_proxy_reports_controller_test.rb
+++ b/test/controllers/ht_ssd_proxy_reports_controller_test.rb
@@ -23,7 +23,7 @@ end
 #   def setup
 #     4.times { create(:ht_log) }
 #   end
-# 
+#
 #   test "export list of all logs as JSON" do
 #     sign_in!
 #     get ht_logs_url format: :json

--- a/test/controllers/ht_ssd_proxy_reports_controller_test.rb
+++ b/test/controllers/ht_ssd_proxy_reports_controller_test.rb
@@ -11,25 +11,27 @@ class HTSSDProxyReportControllerTest < ActionDispatch::IntegrationTest
     sign_in!
     get ht_ssd_proxy_reports_url
     assert_response :success
-    assert_not_nil assigns(:reports)
     assert_not_nil assigns(:time_start)
     assert_not_nil assigns(:time_end)
     assert_equal "index", @controller.action_name
     assert_match "SSD Proxy Reports", @response.body
   end
-end
 
-# class HTLogsControllerJSONTest < ActionDispatch::IntegrationTest
-#   def setup
-#     4.times { create(:ht_log) }
-#   end
-#
-#   test "export list of all logs as JSON" do
-#     sign_in!
-#     get ht_logs_url format: :json
-#     HTLog.all.each do |log|
-#       assert_match log.objid, @response.body
-#     end
-#     assert_kind_of Array, JSON.parse(@response.body)
-#   end
-# end
+  class HTSSDProxyReportControllerJSONTest < ActionDispatch::IntegrationTest
+    def setup
+      10.times { create(:ht_ssd_proxy_report) }
+    end
+
+    test "export list of all reports as JSON" do
+      sign_in!
+      get ht_ssd_proxy_reports_url format: :json
+      HTSSDProxyReport.all.each do |report|
+        assert_match report.htid, @response.body
+        assert_match report.email, @response.body
+        assert_match report.ht_hathifile.author, @response.body
+        assert_match report.institution_name, @response.body
+      end
+      assert_kind_of Hash, JSON.parse(@response.body)
+    end
+  end
+end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -151,7 +151,7 @@ FactoryBot.define do
     sequence(:id) { |n| n.to_s }
     datetime = Faker::Time.backward
     in_copyright { [0, 1].sample }
-    yyyy {  datetime.year }
+    yyyy { datetime.year }
     yyyymm { datetime.strftime("%Y%m") }
     datetime { datetime }
     htid { Faker::Lorem.unique.characters(number: 10) }
@@ -163,7 +163,7 @@ FactoryBot.define do
   end
 
   factory :ht_hathifile do
-    htid { htid = Faker::Alphanumeric.alpha(number: [2, 3]) + "." + Faker::Alphanumeric.alphanumeric(number: 14) }
+    htid { Faker::Alphanumeric.alpha(number: [2, 3]) + "." + Faker::Alphanumeric.alphanumeric(number: 14) }
     access { [nil, true, false].sample }
     rights_code { ["ic", "pd", "pdus", "icus", "und"].sample }
     bib_num { Faker::Number.number(digits: 9) }

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -161,6 +161,10 @@ FactoryBot.define do
     sha { SecureRandom.urlsafe_base64(20) }
     ht_hathifile
     ht_institution
+
+    trait :no_hf do
+      ht_hathifile { nil }
+    end
   end
 
   factory :ht_hathifile do

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -160,6 +160,7 @@ FactoryBot.define do
     inst_code { Faker::Internet.unique.domain_word }
     sha { SecureRandom.urlsafe_base64(20) }
     ht_hathifile
+    ht_institution
   end
 
   factory :ht_hathifile do

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -146,4 +146,32 @@ FactoryBot.define do
     time { Faker::Time.backward }
     data { '{"action"=>"ht_contacts#update", "ip_address"=>"127.0.0.1", "params"=>{"inst_id"=>"bartoletti-bins", "contact_type"=>"7", "email"=>"rosann@hettinger.edu"}, "user_agent"=>"WhizzyAgent", "client_ip"=>"127.0.0.1"}' }
   end
+
+  factory :ht_ssd_proxy_report do
+    sequence(:id) { |n| n.to_s }
+    datetime = Faker::Time.backward
+    in_copyright { [0, 1].sample }
+    yyyy {  datetime.year }
+    yyyymm { datetime.strftime("%Y%m") }
+    datetime { datetime }
+    htid { Faker::Lorem.unique.characters(number: 10) }
+    is_partial { [0, 1].sample }
+    email { Faker::Internet.email }
+    inst_code { Faker::Internet.unique.domain_word }
+    sha { SecureRandom.urlsafe_base64(20) }
+    ht_hathifile
+  end
+
+  factory :ht_hathifile do
+    htid { htid = Faker::Alphanumeric.alpha(number: [2, 3]) + "." + Faker::Alphanumeric.alphanumeric(number: 14) }
+    access { [nil, true, false].sample }
+    rights_code { ["ic", "pd", "pdus", "icus", "und"].sample }
+    bib_num { Faker::Number.number(digits: 9) }
+    title { Faker::Book.title }
+    imprint { Faker::Book.publisher + ", " + Faker::Date.between(from: "1800-01-01", to: "2000-01-01").year.to_s }
+    author { Faker::Book.author }
+    content_provider_code { Faker::Alphanumeric.alpha(number: [2, 3]) }
+    digitization_agent_code { Faker::Alphanumeric.alpha(number: [2, 3]) }
+    rights_date_used { Faker::Date.between(from: "1800-01-01", to: "2000-01-01").year.to_s }
+  end
 end

--- a/test/models/ht_hathifile_test.rb
+++ b/test/models/ht_hathifile_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class HTHathifileTest < ActiveSupport::TestCase
+  test ".ransackable_attributes" do
+    assert_kind_of Array, HTHathifile.ransackable_attributes
+  end
+
+  test ".ransackable_associations" do
+    assert_kind_of Array, HTHathifile.ransackable_associations
+  end
+end

--- a/test/models/ht_institution_test.rb
+++ b/test/models/ht_institution_test.rb
@@ -8,6 +8,10 @@ class HTInstitutionTest < ActiveSupport::TestCase
     @disabled = create(:ht_institution, enabled: false)
   end
 
+  test ".ransackable_attributes" do
+    assert_kind_of Array, HTInstitution.ransackable_attributes
+  end
+
   test "validation passes" do
     assert build(:ht_institution).valid?
   end

--- a/test/models/ht_ssd_proxy_report_test.rb
+++ b/test/models/ht_ssd_proxy_report_test.rb
@@ -7,7 +7,7 @@ class HTSSDProxyReportTest < ActiveSupport::TestCase
   test "validation passes" do
     assert build(:ht_ssd_proxy_report).valid?
   end
-  
+
   test "#institution_name" do
     build(:ht_ssd_proxy_report) do |rep|
       create(:ht_user) do |user|

--- a/test/models/ht_ssd_proxy_report_test.rb
+++ b/test/models/ht_ssd_proxy_report_test.rb
@@ -8,6 +8,14 @@ class HTSSDProxyReportTest < ActiveSupport::TestCase
     assert build(:ht_ssd_proxy_report).valid?
   end
 
+  test ".ransackable_attributes" do
+    assert_kind_of Array, HTSSDProxyReport.ransackable_attributes
+  end
+
+  test ".ransackable_associations" do
+    assert_kind_of Array, HTSSDProxyReport.ransackable_associations
+  end
+
   test "#institution_name" do
     build(:ht_ssd_proxy_report) do |rep|
       create(:ht_user) do |user|

--- a/test/models/ht_ssd_proxy_report_test.rb
+++ b/test/models/ht_ssd_proxy_report_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "ht_ssd_proxy_report"
+
+class HTSSDProxyReportTest < ActiveSupport::TestCase
+  test "validation passes" do
+    assert build(:ht_ssd_proxy_report).valid?
+  end
+  
+  test "#institution_name" do
+    build(:ht_ssd_proxy_report) do |rep|
+      create(:ht_user) do |user|
+        rep.email = user.email
+        rep.inst_code = user.ht_institution.inst_id
+        assert rep.institution_name
+      end
+    end
+  end
+
+  test "#hf" do
+    build(:ht_ssd_proxy_report) do |rep|
+      assert rep.hf
+    end
+  end
+end

--- a/test/presenters/ht_ssd_proxy_report_presenter_test.rb
+++ b/test/presenters/ht_ssd_proxy_report_presenter_test.rb
@@ -20,6 +20,14 @@ class HTSSDProxyReportPresenterTest < ActiveSupport::TestCase
     end
   end
 
+  test "hf show methods work for nonexistent hf entry" do
+    report = create(:ht_ssd_proxy_report, :no_hf)
+    report = HTSSDProxyReportPresenter.new(report, action: :index)
+    HTSSDProxyReportPresenter::HF_FIELDS.each do |field|
+      assert_equal report.send("show_#{field}"), ""
+    end
+  end
+
   test "show datetime" do
     report = HTSSDProxyReportPresenter.new(create(:ht_ssd_proxy_report), action: :index)
     assert_match(/\d\d\d\d-\d\d-\d\d/, report.field_value(:datetime))

--- a/test/presenters/ht_ssd_proxy_report_presenter_test.rb
+++ b/test/presenters/ht_ssd_proxy_report_presenter_test.rb
@@ -22,14 +22,14 @@ class HTSSDProxyReportPresenterTest < ActiveSupport::TestCase
 
   test "show datetime" do
     report = HTSSDProxyReportPresenter.new(create(:ht_ssd_proxy_report), action: :index)
-    assert_match /\d\d\d\d-\d\d-\d\d/, report.field_value(:datetime)
+    assert_match(/\d\d\d\d-\d\d-\d\d/, report.field_value(:datetime))
   end
-  
+
   test "show email" do
     report = HTSSDProxyReportPresenter.new(create(:ht_ssd_proxy_report), action: :index)
     assert_match "href=", report.field_value(:email)
   end
-  
+
   test "show institution name" do
     create(:ht_ssd_proxy_report) do |rep|
       create(:ht_institution) do |inst|

--- a/test/presenters/ht_ssd_proxy_report_presenter_test.rb
+++ b/test/presenters/ht_ssd_proxy_report_presenter_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class HTSSDProxyReportPresenterTest < ActiveSupport::TestCase
+  test "class constants" do
+    assert_not_nil HTSSDProxyReportPresenter::ALL_FIELDS
+    assert_not_nil HTSSDProxyReportPresenter::DATA_FILTER_CONTROLS
+    assert_not_nil HTSSDProxyReportPresenter::HF_FIELDS
+  end
+
+  test "data filter controls" do
+    assert_equal HTSSDProxyReportPresenter.data_filter_control(:datetime), "datepicker"
+  end
+
+  test "hf fields have show methods" do
+    report = HTSSDProxyReportPresenter.new(create(:ht_ssd_proxy_report), action: :index)
+    HTSSDProxyReportPresenter::HF_FIELDS.each do |field|
+      assert report.send("show_#{field}")
+    end
+  end
+
+  test "show datetime" do
+    report = HTSSDProxyReportPresenter.new(create(:ht_ssd_proxy_report), action: :index)
+    assert_match /\d\d\d\d-\d\d-\d\d/, report.field_value(:datetime)
+  end
+  
+  test "show email" do
+    report = HTSSDProxyReportPresenter.new(create(:ht_ssd_proxy_report), action: :index)
+    assert_match "href=", report.field_value(:email)
+  end
+  
+  test "show institution name" do
+    create(:ht_ssd_proxy_report) do |rep|
+      create(:ht_institution) do |inst|
+        rep.inst_code = inst.inst_id
+        report = HTSSDProxyReportPresenter.new(rep, action: :index)
+        assert_match "href=", report.field_value(:institution_name)
+      end
+    end
+  end
+end

--- a/test/presenters/ht_ssd_proxy_report_presenter_test.rb
+++ b/test/presenters/ht_ssd_proxy_report_presenter_test.rb
@@ -9,8 +9,10 @@ class HTSSDProxyReportPresenterTest < ActiveSupport::TestCase
     assert_not_nil HTSSDProxyReportPresenter::HF_FIELDS
   end
 
-  test "data filter controls" do
-    assert_equal HTSSDProxyReportPresenter.data_filter_control(:datetime), "datepicker"
+  test "each field has a data filter control" do
+    HTSSDProxyReportPresenter::ALL_FIELDS.each do |field|
+      assert_kind_of String, HTSSDProxyReportPresenter.data_filter_control(field)
+    end
   end
 
   test "hf fields have show methods" do

--- a/test/system/ht_ssd_proxy_reports_test.rb
+++ b/test/system/ht_ssd_proxy_reports_test.rb
@@ -1,0 +1,8 @@
+require "application_system_test_case"
+
+class HTSSDProxyReportsTest < ApplicationSystemTestCase
+  test "visit index" do
+    visit_with_login ht_ssd_proxy_reports_url
+    assert_selector "h1", text: "SSD Proxy Reports"
+  end
+end


### PR DESCRIPTION
This PR adds a new page to Otis: SSD Proxy Reports, based on a facility hidden away in PageTurner. The existing facility uses some of the advanced features of Bootstrap Tables that have been replicated here, and (one hopes) improved upon. Otis uses Bootstrap Tables but until now has not taken advantage of advanced search features, pagination, data export, or a server-side provider (via `format=json`).

Most of the changes in this PR are boilerplate - two new database tables, seeds and factories for them, localizations.

## For the Reviewer
- Proceed with this branch locally as described in the README by building and running the `web` service.
- Please evaluate the basic functionality at `http://0.0.0.0:3000/useradmin/ht_ssd_proxy_reports`, logging in as `admin@default.invalid`. The behavior should at least resemble https://babel.hathitrust.org/cgi/pt/reports/ssdproxy
- The controller at `app/controllers/ht_ssd_proxy_reports_controller.rb` has fairly extensive notes and comments. Do they make sense?
- In future we may want to extend this approach (Bootstrap Table with server-side data source and per-column search controls). Poorly-named data or methods will make this less intuitive so please object to anything that violates the Principle of Least Astonishment.


