### PR TITLE
DEV-1609 manually renewing user causes double renewal

### DIFF
--- a/app/controllers/ht_approval_requests_controller.rb
+++ b/app/controllers/ht_approval_requests_controller.rb
@@ -115,7 +115,9 @@ class HTApprovalRequestsController < ApplicationController
     end
     adds = []
     emails.each do |e|
-      HTUser.find(e).add_or_update_renewal(approver: current_user.id)
+      ht_user = HTUser.find(e)
+      ht_user.add_or_update_renewal(approver: current_user.id)
+      ht_user.renew!
       adds << e
     rescue HTUserRenewalError => err
       flash[:alert] = t ".errors.#{err.type}", user: e

--- a/app/controllers/ht_users_controller.rb
+++ b/app/controllers/ht_users_controller.rb
@@ -26,7 +26,7 @@ class HTUsersController < ApplicationController
     renewing = user_params[:expires].present? && user_params[:expires] > @user.expires.to_date.to_s
 
     if @user.update(user_params)
-      @user.add_or_update_renewal(approver: current_user.id, force: true, renew_user: false) if renewing
+      @user.add_or_update_renewal(approver: current_user.id, force: true) if renewing
       log_action(@user, user_params)
       update_user_success
     else

--- a/app/controllers/ht_users_controller.rb
+++ b/app/controllers/ht_users_controller.rb
@@ -26,7 +26,7 @@ class HTUsersController < ApplicationController
     renewing = user_params[:expires].present? && user_params[:expires] > @user.expires.to_date.to_s
 
     if @user.update(user_params)
-      @user.add_or_update_renewal(approver: current_user.id, force: true) if renewing
+      @user.add_or_update_renewal(approver: current_user.id, force: true, renew_user: false) if renewing
       log_action(@user, user_params)
       update_user_success
     else

--- a/app/models/ht_user.rb
+++ b/app/models/ht_user.rb
@@ -149,16 +149,13 @@ class HTUser < ApplicationRecord
     save!
   end
 
-  # Called when an approval request is renewed, and when a user's expiration is edited.
+  # Called when a user is renewed via approval request, and when a user's expiration is edited.
   # If `force`, makes sure there is an appropriate approval request in place,
   # creating one out of thin air if necessary.
-  # If `renew_user` then the user's renewal date is updated. Call with `renew_user: false`
-  # when updating the expiration manually, otherwise the edited date will be
-  # further bumped by the renewal period.
-  # Note that the `force` and `renew_user` parameters are expected to be called
-  # with values opposite each other. The defaults represent the path from the
-  # approval request subsystem.
-  def add_or_update_renewal(approver:, force: false, renew_user: true)
+  # Note: this does not actually renew the user (i.e., bump `ht_user.expiration_date`);
+  # that is the caller's responsibility to do if needed. (Earlier versions called `renew!` here
+  # but could cause double renewal if the user was being manually edited.)
+  def add_or_update_renewal(approver:, force: false)
     req = ht_approval_request.approved.not_renewed.first
 
     if force
@@ -170,7 +167,6 @@ class HTUser < ApplicationRecord
 
     req.renewed = Time.zone.now
     req.save!
-    renew! if renew_user
   end
 
   def csv_cols

--- a/app/models/ht_user.rb
+++ b/app/models/ht_user.rb
@@ -149,7 +149,16 @@ class HTUser < ApplicationRecord
     save!
   end
 
-  def add_or_update_renewal(approver:, force: false)
+  # Called when an approval request is renewed, and when a user's expiration is edited.
+  # If `force`, makes sure there is an appropriate approval request in place,
+  # creating one out of thin air if necessary.
+  # If `renew_user` then the user's renewal date is updated. Call with `renew_user: false`
+  # when updating the expiration manually, otherwise the edited date will be
+  # further bumped by the renewal period.
+  # Note that the `force` and `renew_user` parameters are expected to be called
+  # with values opposite each other. The defaults represent the path from the
+  # approval request subsystem.
+  def add_or_update_renewal(approver:, force: false, renew_user: true)
     req = ht_approval_request.approved.not_renewed.first
 
     if force
@@ -161,7 +170,7 @@ class HTUser < ApplicationRecord
 
     req.renewed = Time.zone.now
     req.save!
-    renew!
+    renew! if renew_user
   end
 
   def csv_cols

--- a/test/controllers/ht_users_controller_test.rb
+++ b/test/controllers/ht_users_controller_test.rb
@@ -225,6 +225,14 @@ class HTUsersControllerRenewalTest < ActionDispatch::IntegrationTest
     assert_equal "admin@default.invalid", @req2.approver
     assert_equal Date.parse(@req2.renewed).to_s, Date.parse(Time.zone.now.to_s).to_s
   end
+
+  test "renewing user manually sets expiration to the submitted date" do
+    sign_in!
+    new_date = (Time.zone.now + 3.years)
+    patch ht_user_url @user2, params: {"ht_user" => {"expires" => new_date.to_s}}
+    @user2.reload
+    assert_equal new_date.to_date, @user2.expires.to_date
+  end
 end
 
 class HTUsersControllerCSVTest < ActionDispatch::IntegrationTest


### PR DESCRIPTION
`HTUser#add_or_update_renewal` was designed to update/create/check the audit trail when a user's expiration date is updated. This can happen via outside approval or manually inside Otis (User->Edit->change date). However, it renewed the user (bumped the expiration date) as a side effect. This behavior is correct when an approval request for a supervisor outside HathiTrust is processed. It is not correct when a manual update is done, because the expiration date gets updated twice: once from the HTML form and a second time by this method.

This patch:
- Adds comments about what `HTUser#add_or_update_renewal` does.
- Moves responsibility for calling `HTUser#renew!` to the caller, specifically `HTApprovalRequestsController`.
- Adds one initially failing test that validates expiration date when a user is edited.