### PR TITLE
TTO-301 Otis: investigate possible missing e-mail registration text

### DIFF
--- a/app/controllers/ht_approval_requests_controller.rb
+++ b/app/controllers/ht_approval_requests_controller.rb
@@ -40,7 +40,7 @@ class HTApprovalRequestsController < ApplicationController
   def update
     begin
       ApprovalRequestMailer.with(reqs: @reqs, base_url: request.base_url,
-        body: params[:email_body], subject: params[:subject]).approval_request_email.deliver_now
+        email_body: params[:email_body], subject: params[:subject]).approval_request_email.deliver_now
       @reqs.each do |req|
         next unless req.mailable?
 

--- a/app/controllers/ht_registrations_controller.rb
+++ b/app/controllers/ht_registrations_controller.rb
@@ -132,7 +132,7 @@ class HTRegistrationsController < ApplicationController
 
   def send_mail
     RegistrationMailer.with(registration: @registration, base_url: request.base_url,
-      body: params[:email_body], subject: params[:subject])
+      email_body: params[:email_body], subject: params[:subject])
       .registration_email.deliver_now
     add_jira_comment template: :registration_sent
     flash[:notice] = t("ht_registrations.mail.success")

--- a/app/mailers/approval_request_mailer.rb
+++ b/app/mailers/approval_request_mailer.rb
@@ -8,8 +8,8 @@ class ApprovalRequestMailer < ApplicationMailer
   def approval_request_email
     @reqs = params[:reqs]
     @base_url = params[:base_url]
-    @body = params[:body]
-    raise StandardError, "Cannot send email without email body" unless @body.present?
+    @email_body = params[:email_body]
+    raise StandardError, "Cannot send email without email body" unless @email_body.present?
 
     @subject = params[:subject] || ApprovalRequestMailer.subject
     raise StandardError, "Cannot send an email without at least one approval request" unless @reqs.count.positive?

--- a/app/mailers/approval_request_mailer.rb
+++ b/app/mailers/approval_request_mailer.rb
@@ -9,6 +9,8 @@ class ApprovalRequestMailer < ApplicationMailer
     @reqs = params[:reqs]
     @base_url = params[:base_url]
     @body = params[:body]
+    raise StandardError, "Cannot send email without email body" unless @body.present?
+
     @subject = params[:subject] || ApprovalRequestMailer.subject
     raise StandardError, "Cannot send an email without at least one approval request" unless @reqs.count.positive?
 

--- a/app/mailers/registration_mailer.rb
+++ b/app/mailers/registration_mailer.rb
@@ -8,10 +8,10 @@ class RegistrationMailer < ApplicationMailer
   def registration_email
     @registration = params[:registration]
     @base_url = params[:base_url]
-    @body = params[:body]
+    @email_body = params[:email_body]
     raise StandardError, "Cannot send email without a registration" unless @registration.present?
     raise StandardError, "Cannot send email without a base URL" unless @base_url.present?
-    raise StandardError, "Cannot send email without email body" unless @body.present?
+    raise StandardError, "Cannot send email without email body" unless @email_body.present?
 
     @subject = params[:subject] || RegistrationMailer.subject
     add_email_signature_logo

--- a/app/mailers/registration_mailer.rb
+++ b/app/mailers/registration_mailer.rb
@@ -8,11 +8,12 @@ class RegistrationMailer < ApplicationMailer
   def registration_email
     @registration = params[:registration]
     @base_url = params[:base_url]
+    @body = params[:body]
     raise StandardError, "Cannot send email without a registration" unless @registration.present?
     raise StandardError, "Cannot send email without a base URL" unless @base_url.present?
+    raise StandardError, "Cannot send email without email body" unless @body.present?
 
     @subject = params[:subject] || RegistrationMailer.subject
-    @body = params[:body]
     add_email_signature_logo
     mail(to: @registration.applicant_email, subject: @subject)
   end

--- a/app/views/approval_request_mailer/approval_request_email.html.erb
+++ b/app/views/approval_request_mailer/approval_request_email.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <%= sanitize(@body) %>
+  <%= sanitize(@email_body) %>
 </div>
 <%= render 'shared/approval_request_user_table' %>
 <%= mailer.show_email_signature_logo %>

--- a/app/views/approval_request_mailer/approval_request_email.text.erb
+++ b/app/views/approval_request_mailer/approval_request_email.text.erb
@@ -1,4 +1,4 @@
-<%= strip_tags @body %>
+<%= strip_tags @email_body %>
 
 Name  E-mail  Activity  Term  Expires
   <% role_stars = {} %>

--- a/app/views/ht_approval_requests/edit.html.erb
+++ b/app/views/ht_approval_requests/edit.html.erb
@@ -42,7 +42,7 @@ window.addEventListener("load", (e)=>{
             <div class="card-title"><%= t ".email_preview" %></div>
             <%= label_tag "subject", t(".subject") %>
             <%= text_field_tag "subject", ApprovalRequestMailer.subject, size: 60 %>
-            <textarea id="email-editor" data-editor="ClassicEditor">
+            <textarea id="email-editor" data-editor="ClassicEditor" name="email_body">
               <%= @email_body %>
             </textarea>
           </div>

--- a/app/views/ht_registrations/preview.html.erb
+++ b/app/views/ht_registrations/preview.html.erb
@@ -28,7 +28,7 @@ window.addEventListener("load", (e)=>{
         <div class="card-title"><%= t ".email_preview" %></div>
         <%= label_tag "subject", t(".subject") %>
         <%= text_field_tag "subject", RegistrationMailer.subject, size: 60 %>
-        <textarea id="email-editor" data-editor="ClassicEditor">
+        <textarea id="email-editor" data-editor="ClassicEditor" name="email_body">
           <%= @email_body %>
         </textarea>
       </div>

--- a/app/views/registration_mailer/registration_email.html.erb
+++ b/app/views/registration_mailer/registration_email.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <%= sanitize(@body) %>
+  <%= sanitize(@email_body) %>
 </div>
 <%= mailer.show_email_signature_logo %>
 <br/><br/>

--- a/app/views/registration_mailer/registration_email.text.erb
+++ b/app/views/registration_mailer/registration_email.text.erb
@@ -1,3 +1,3 @@
-<%= strip_tags @body %>
+<%= strip_tags @email_body %>
 
 <%= finalize_url(@registration.token, host: @base_url, locale: nil)%>

--- a/test/controllers/ht_approval_requests_controller_test.rb
+++ b/test/controllers/ht_approval_requests_controller_test.rb
@@ -121,6 +121,8 @@ class HTApprovalRequestControllerUpdateTest < ActionDispatch::IntegrationTest
 
   def patch_approval_request(approver = @user.approver, params: {})
     sign_in!
+    # Required lest mailer raise
+    params[:email_body] ||= "test body"
     patch ht_approval_request_url approver, params: params
     assert_response :redirect
     assert_equal "update", @controller.action_name
@@ -191,7 +193,7 @@ class HTApprovalRequestControllerResendTest < ActionDispatch::IntegrationTest
 
   test "resending e-mail resets sent timestamp" do
     sign_in!
-    patch ht_approval_request_url @user.approver
+    patch ht_approval_request_url @user.approver, params: {email_body: "test body"}
     follow_redirect!
     assert_equal Date.parse(@req.reload.sent).to_s, Date.parse(Time.zone.now.to_s).to_s
   end

--- a/test/controllers/ht_registrations_controller_test.rb
+++ b/test/controllers/ht_registrations_controller_test.rb
@@ -351,6 +351,8 @@ class HTRegistrationsControllerMailTest < ActionDispatch::IntegrationTest
 
   def mail_registration(registration: @registration, params: {})
     sign_in!
+    # Required param for mailer
+    params[:email_body] ||= "test body"
     post(mail_ht_registration_path(registration), params: params)
     assert_response :redirect
     assert_equal "mail", @controller.action_name

--- a/test/mailers/approval_request_mailer_test.rb
+++ b/test/mailers/approval_request_mailer_test.rb
@@ -15,7 +15,7 @@ class ApprovalRequestMailerTest < ActionMailer::TestCase
 
   def email(reqs: [@req1], base_url: @base_url, body: "test body")
     ApprovalRequestMailer
-      .with(reqs: reqs, base_url: base_url, body: body)
+      .with(reqs: reqs, base_url: base_url, email_body: body)
       .approval_request_email
   end
 

--- a/test/mailers/approval_request_mailer_test.rb
+++ b/test/mailers/approval_request_mailer_test.rb
@@ -13,7 +13,7 @@ class ApprovalRequestMailerTest < ActionMailer::TestCase
     @req3 = create(:ht_approval_request, userid: @user3.email, approver: @user3.approver)
   end
 
-  def email(reqs: [@req1], base_url: @base_url, body: "")
+  def email(reqs: [@req1], base_url: @base_url, body: "test body")
     ApprovalRequestMailer
       .with(reqs: reqs, base_url: base_url, body: body)
       .approval_request_email
@@ -91,5 +91,11 @@ class ApprovalRequestMailerTest < ActionMailer::TestCase
 
   test "mail has HathiTrust logo PNG attachment" do
     assert_match %r{image/png}, email.attachments[0].content_type
+  end
+
+  test "mailer raises if body is not present" do
+    assert_raise StandardError do
+      ApprovalRequestMailer.with(reqs: reqs, base_url: base_url)
+    end
   end
 end

--- a/test/mailers/previews/approval_request_mailer_preview.rb
+++ b/test/mailers/previews/approval_request_mailer_preview.rb
@@ -9,6 +9,6 @@ class ApprovalRequestMailerPreview < ActionMailer::Preview
     end
     controller = ActionController::Base.new
     body = controller.render_to_string partial: "shared/approval_request_body"
-    ApprovalRequestMailer.with(reqs: reqs, body: body, base_url: "http://default.invalid").approval_request_email
+    ApprovalRequestMailer.with(reqs: reqs, email_body: body, base_url: "http://default.invalid").approval_request_email
   end
 end

--- a/test/mailers/previews/registration_mailer_preview.rb
+++ b/test/mailers/previews/registration_mailer_preview.rb
@@ -9,7 +9,7 @@ class RegistrationMailerPreview < ActionMailer::Preview
     body = controller.render_to_string(partial: "shared/registration_body",
       locals: {"@registration": reg})
       .gsub("__NAME__", reg.applicant_name)
-    RegistrationMailer.with(registration: reg, body: body, base_url: base_url)
+    RegistrationMailer.with(registration: reg, email_body: body, base_url: base_url)
       .registration_email
   end
 end

--- a/test/mailers/registration_mailer_test.rb
+++ b/test/mailers/registration_mailer_test.rb
@@ -8,7 +8,7 @@ class RegistrationMailerTest < ActionMailer::TestCase
   end
 
   def email(reg: @reg)
-    RegistrationMailer.with(registration: reg, base_url: "example.com", body: "test body")
+    RegistrationMailer.with(registration: reg, base_url: "example.com", email_body: "test body")
       .registration_email
   end
 

--- a/test/mailers/registration_mailer_test.rb
+++ b/test/mailers/registration_mailer_test.rb
@@ -8,7 +8,7 @@ class RegistrationMailerTest < ActionMailer::TestCase
   end
 
   def email(reg: @reg)
-    RegistrationMailer.with(registration: reg, base_url: "example.com")
+    RegistrationMailer.with(registration: reg, base_url: "example.com", body: "test body")
       .registration_email
   end
 
@@ -42,5 +42,11 @@ class RegistrationMailerTest < ActionMailer::TestCase
 
   test "mail has HathiTrust logo PNG attachment" do
     assert_match %r{image/png}, email.attachments[0].content_type
+  end
+
+  test "mailer raises if body is not present" do
+    assert_raise StandardError do
+      RegistrationMailer.with(registration: reg, base_url: "example.com")
+    end
   end
 end


### PR DESCRIPTION
In the migration from `ckeditor` 4 to 5 the `textarea` that contains the email body (for approval request and registration emails) lost its `name` attribute, so we sent out some emails that omitted most of the intended content.

- Restore `email_body` form element name to approval request and registration email previews.
  - The changes in this PR that actually fix the bug are in `preview.html.erb` and `edit.html.erb`, everything else is just tests & tidy.
- Mailers now raise if the `email_body` is omitted. Better a 500 than a mostly blank e-mail being sent. This required some modifications to the tests, to make sure we have some fake body text.
- TIDY phase: at the Controller-Mailer interface the `email_body` param was getting renamed to just `body` as a Mailer instance variable. For naming continuity -- to make this bucket chain more understandable -- this is now `email_body` all the way thru. Unfortunately this sneezed a lot of changes into the `diff` for this branch but they can be ignored.